### PR TITLE
Add stack-efficient MAYO

### DIFF
--- a/crypto_sign/mayo1/m4stack/aes_ctr.c
+++ b/crypto_sign/mayo1/m4stack/aes_ctr.c
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * This is an implementation of AES128 in CTR mode with IV = 0, as required by
+ * the Mayo signature scheme. Also we expose the AES-256 ECB encryption function
+ * for KAT testing purposes.
+ * 
+ * This code is not secure against side-channel attacks as in MAYO it is only
+ * used for public key expansion and not in secret-dependent operations.
+ */
+
+#include <string.h>
+
+#include "aes_ctr.h"
+
+static const uint8_t sbox[256] = {
+    0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+    0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+    0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+    0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+    0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+    0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+    0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+    0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+    0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+    0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+    0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+    0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+    0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+    0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+    0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+    0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16 };
+
+static const uint8_t rcon[11] = {
+    0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36 };
+
+static inline void key_expansion(uint8_t *round_keys, const uint8_t *key, int key_len) {
+    int i, j;
+    uint8_t word[4];
+
+    for (i = 0; i < key_len; i++) {
+        round_keys[i] = key[i];
+    }
+
+    int n = key_len / 4;  // number of 4-byte words in the original key
+    int nwords = 4 * (7 + n);  // number of 4-byte words in the expanded key
+
+    for (i = n; i < nwords; i++) {
+        // W[i-1]
+        for (j = 0; j < 4; j++) {
+            word[j] = round_keys[i * 4 - 4 + j];
+        }
+
+        if (i % n == 0) {
+            // Rotate
+            uint8_t temp = word[0];
+            word[0] = word[1];
+            word[1] = word[2];
+            word[2] = word[3];
+            word[3] = temp;
+
+            // SubBytes
+            for (j = 0; j < 4; j++) {
+                word[j] = sbox[word[j]];
+            }
+
+            // Rcon
+            word[0] ^= rcon[i / n];
+        } else if (n > 6 && i % n == 4) {
+            // SubBytes
+            for (j = 0; j < 4; j++) {
+                word[j] = sbox[word[j]];
+            }
+        }
+
+        for (j = 0; j < 4; j++) {
+            round_keys[i * 4 + j] = round_keys[(i - n) * 4 + j] ^ word[j];
+        }
+    }
+}
+
+static inline void add_round_key(uint8_t state[16], const uint8_t round_key[16]) {
+    int i;
+    for (i = 0; i < 16; i++) {
+        state[i] ^= round_key[i];
+    }
+}
+
+static inline void sub_bytes(uint8_t state[16]) {
+    int i;
+    for (i = 0; i < 16; i++) {
+        state[i] = sbox[state[i]];
+    }
+}
+
+static inline void shift_rows(uint8_t state[16]) {
+    uint8_t temp;
+
+    // Row 1
+    temp = state[1];
+    state[1] = state[5];
+    state[5] = state[9];
+    state[9] = state[13];
+    state[13] = temp;
+
+    // Row 2
+    temp = state[2];
+    state[2] = state[10];
+    state[10] = temp;
+    temp = state[6];
+    state[6] = state[14];
+    state[14] = temp;
+
+    // Row 3
+    temp = state[3];
+    state[3] = state[15];
+    state[15] = state[11];
+    state[11] = state[7];
+    state[7] = temp;
+}
+
+static inline uint8_t xtime(uint8_t x) {
+    return (x << 1) ^ ((x >> 7) * 0x1b);
+}
+
+static inline void mix_columns(uint8_t state[16]) {
+    uint8_t a, b, c, d;
+    int i;
+    for (i = 0; i < 16; i += 4) {
+        a = state[i + 0];
+        b = state[i + 1];
+        c = state[i + 2];
+        d = state[i + 3];
+
+        state[i + 0] = xtime(a) ^ (xtime(b) ^ b) ^ c ^ d;
+        state[i + 1] = a ^ xtime(b) ^ (xtime(c) ^ c) ^ d;
+        state[i + 2] = a ^ b ^ xtime(c) ^ (xtime(d) ^ d);
+        state[i + 3] = (xtime(a) ^ a) ^ b ^ c ^ xtime(d);
+    }
+}
+
+static inline void cipher(uint8_t state[16], const uint8_t *round_keys, int nrounds) {
+    int i;
+
+    add_round_key(state, round_keys);
+
+    for (i = 16; i < (nrounds - 1) * 16; i += 16) {
+        sub_bytes(state);
+        shift_rows(state);
+        mix_columns(state);
+        add_round_key(state, round_keys + i);
+    }
+
+    sub_bytes(state);
+    shift_rows(state);
+    add_round_key(state, round_keys + (nrounds - 1) * 16);
+}
+
+void aes128ctr_init(aes128ctr_ctx *ctx, const uint8_t key[16]) {
+    int i;
+    key_expansion(ctx->round_keys, key, 16);
+    for (i = 0; i < 16; i++) {
+        ctx->state[i] = 0;
+    }
+    ctx->pos = 0;  // force initial block generation
+}
+
+void aes128ctr_stream(uint8_t *out, int outlen, aes128ctr_ctx *ctx) {
+    int i;
+
+    if (ctx->pos % 16 != 0) {
+        // Use remaining bytes from current block
+        for (i = ctx->pos % 16; i < 16 && outlen > 0; i++, out++, outlen--) {
+            *out = ctx->state[i];
+        }
+        ctx->pos += i - (ctx->pos % 16);
+    }
+    
+    while (outlen > 16) {
+        // Set up counter in state
+        for (i = 0; i < 8; i++) {
+            ctx->state[15 - i] = (ctx->pos >> (8 * i + 4)) & 0xFF;
+        }
+        for (i = 0; i < 8; i++) {
+            ctx->state[7 - i] = 0;
+        }
+        
+        // Generate next block
+        cipher(ctx->state, ctx->round_keys, 11);
+        
+        // Output full block
+        for (i = 0; i < 16; i++, out++) {
+            *out = ctx->state[i];
+        }
+        ctx->pos += 16;
+        outlen -= 16;
+    }      
+    
+    if (outlen > 0) {
+        // Set up counter in state
+        for (i = 0; i < 8; i++) {
+            ctx->state[15 - i] = (ctx->pos >> (8 * i + 4)) & 0xFF;
+        }
+        for (i = 0; i < 8; i++) {
+            ctx->state[7 - i] = 0;
+        }
+        
+        // Generate next block
+        cipher(ctx->state, ctx->round_keys, 11);
+        
+        // Output remaining bytes
+        for (i = 0; i < outlen; i++, out++) {
+            *out = ctx->state[i];
+        }
+        ctx->pos += outlen;
+    }
+}
+
+void aes256ecb(const uint8_t *key, const uint8_t *input, uint8_t *output) {
+    uint8_t round_keys[15 * 16];
+    uint8_t state[16];
+    key_expansion(round_keys, key, 32);
+    memcpy(state, input, 16);
+    cipher(state, round_keys, 15);
+    memcpy(output, state, 16);
+}

--- a/crypto_sign/mayo1/m4stack/aes_ctr.h
+++ b/crypto_sign/mayo1/m4stack/aes_ctr.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef AES128CTR_H
+#define AES128CTR_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// AES-128-CTR context structure
+typedef struct aes128ctr_ctx {
+    uint8_t round_keys[11 * 16];  // expanded AES key
+    uint8_t state[16];  // current output block
+    uint64_t pos;  // position in the current keystream in bytes (lower 4 bits are offset in block, upper bits are block counter)
+} aes128ctr_ctx;
+
+/**
+ * Initializes the AES-128-CTR context with the given key.
+ * 
+ * @param[out] ctx Pointer to the AES-128-CTR context to initialize
+ * @param[in] key 16-byte AES key
+ */
+void aes128ctr_init(aes128ctr_ctx *ctx, const uint8_t key[16]);
+
+/**
+ * Generates AES-128-CTR keystream and writes it to the output buffer.
+ * 
+ * @param[out] out Output buffer to write the keystream
+ * @param[in] outlen Length of the output buffer in bytes
+ * @param[in,out] ctx Pointer to the AES-128-CTR context
+ */
+void aes128ctr_stream(uint8_t *out, int outlen, aes128ctr_ctx *ctx);
+
+/**
+ * AES ECB encryption function. Used by randombytes_ctrdrbg.c for KAT testing.
+ */
+void aes256ecb(const uint8_t *key, const uint8_t *input, uint8_t *output);
+#define AES_ECB_encrypt(input, key, output) aes256ecb(key, input, output);
+
+#endif  // AES128CTR_H

--- a/crypto_sign/mayo1/m4stack/api.c
+++ b/crypto_sign/mayo1/m4stack/api.c
@@ -1,0 +1,18 @@
+#include <api.h>
+#include <mayo.h>
+
+int crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+    return mayo_keypair(pk, sk);
+}
+
+int crypto_sign(unsigned char *sm, size_t *smlen, 
+                const unsigned char *m, size_t mlen, 
+                const unsigned char *sk) {
+    return mayo_sign(sm, smlen, m, mlen, sk);
+}
+
+int crypto_sign_open(unsigned char *m, size_t *mlen, 
+                     const unsigned char *sm, size_t smlen, 
+                     const unsigned char *pk) {
+    return mayo_open(m, mlen, sm, smlen, pk);
+}

--- a/crypto_sign/mayo1/m4stack/api.c
+++ b/crypto_sign/mayo1/m4stack/api.c
@@ -2,17 +2,17 @@
 #include <mayo.h>
 
 int crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
-    return mayo_keypair(pk, sk);
+    return mayo_keypair(NULL, pk, sk);
 }
 
 int crypto_sign(unsigned char *sm, size_t *smlen, 
                 const unsigned char *m, size_t mlen, 
                 const unsigned char *sk) {
-    return mayo_sign(sm, smlen, m, mlen, sk);
+    return mayo_sign(NULL, sm, smlen, m, mlen, sk);
 }
 
 int crypto_sign_open(unsigned char *m, size_t *mlen, 
                      const unsigned char *sm, size_t smlen, 
                      const unsigned char *pk) {
-    return mayo_open(m, mlen, sm, smlen, pk);
+    return mayo_open(NULL, m, mlen, sm, smlen, pk);
 }

--- a/crypto_sign/mayo1/m4stack/api.h
+++ b/crypto_sign/mayo1/m4stack/api.h
@@ -1,0 +1,23 @@
+#ifndef API_H
+#define API_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "params.h"
+
+// NIST/SUPERCOP/PQClean API for signature schemes
+
+#define CRYPTO_SECRETKEYBYTES CSK_BYTES
+#define CRYPTO_PUBLICKEYBYTES CPK_BYTES
+#define CRYPTO_BYTES SIG_BYTES
+
+int crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
+int crypto_sign(unsigned char *sm, size_t *smlen, 
+                const unsigned char *m, size_t mlen, 
+                const unsigned char *sk);
+int crypto_sign_open(unsigned char *m, size_t *mlen, 
+                     const unsigned char *sm, size_t smlen, 
+                     const unsigned char *pk);
+
+#endif  // API_H

--- a/crypto_sign/mayo1/m4stack/arithmetic.c
+++ b/crypto_sign/mayo1/m4stack/arithmetic.c
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdalign.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "arithmetic.h"
+#include "aes_ctr.h"
+
+void compute_P3(uint8_t P3[P3_BYTES],
+                const uint8_t seed_pk[PK_SEED_BYTES],
+                const uint8_t O[O_BYTES]) {
+    // aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    aes128ctr_ctx ctx;
+    int row, col;
+
+    aes128ctr_init(&ctx, seed_pk);  // initialize AES-128-CTR with seed_pk
+    
+    // Here we use the notation from the specification document.
+    // So the parameters are in lowercase letters instead of uppercase macros.
+    // e.g. n = PARAM_N, o = PARAM_O, m = PARAM_M, etc.
+
+    // Compute P3_h = Upper(-O^T * P1_h * O - O^T * P2_h) minimizing temporary storage
+    // The entries of the matrices P1_h (resp. P2_h) are obtained following the order (i, j, h) where
+    // - i is the row index
+    // - j is the column index
+    // - h is the matrix index
+    // So the first m entries are the (0, 0) coefficients of all m matrices,
+    // then the next m entries are the (0, 1) coefficients of all m matrices, and so on.
+    
+    // Each P1_h is a (n - o) * (n - o) upper-triangular matrix
+    // Each P2_h is a (n - o) * o full matrix
+    // Each P3_h is a o * o upper-triangular matrix (transformed to upper-triangular in place)
+    // O is a (n - o) * o full matrix
+    
+    // Compute -O^T * P1_h * O and accumulate into P3_h
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = row; col < PARAM_N - PARAM_O; col++) {
+            // compute entry P1_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, &ctx);
+            // accumulate into P3_h the value O^T[:, row] * P1_h[row, col] * O[col, :]
+            compute_P3_from_P1(P3, entry, O, row, col);
+        }
+    }
+    // Compute -O^T * P2_h and accumulate into P3_h
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = 0; col < PARAM_O; col++) {
+            // compute entry P2_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, &ctx);
+            // accumulate into P3_h the value O^T[:, row] * P2_h[row, col]
+            compute_P3_from_P2(P3, entry, O, row, col);
+        }
+    }
+}
+
+void compute_L(uint8_t L[L_BYTES],
+               const uint8_t O[O_BYTES],
+               const uint8_t P1[P1_BYTES],
+               aes128ctr_ctx *ctx) {
+    // aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    int row, col;
+    uint8_t *ptr;
+    
+    memset(L, 0, L_BYTES);  // initialize L to zero
+
+    // Use P1_h to accumulate into L
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        // skip computation for row == col since the diagonal of P1_h + P1_h^T is zero
+        for (col = row + 1; col < PARAM_N - PARAM_O; col++) {
+            // retrieve entry P1_h[row, col] for all m matrices
+            ptr = m_utmatrix_entry_ptr((uint8_t *)P1, row, col, PARAM_N - PARAM_O);
+            memcpy(entry, ptr, M_ENTRIES_BYTES);  // no leak since P1 is public
+            compute_L_from_P1(L, entry, O, row, col);
+        }
+    }
+    // Use P2_h to accumulate into L
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = 0; col < PARAM_O; col++) {
+            // compute entry P2_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, ctx);
+            // accumulate into L the value P2_h[row, col]
+            ptr = m_matrix_entry_ptr(L, row, col, PARAM_O);
+            vec_add_u8(ptr, entry, M_ENTRIES_BYTES);
+        }
+    }
+}
+
+void build_linear_system(uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                         uint8_t y[M_ENTRIES_BYTES],
+                         const uint8_t seed_pk[PK_SEED_BYTES],
+                         const uint8_t O[O_BYTES],
+                         const uint8_t V[PARAM_K * V_BYTES]) {
+    // aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    // buf contains either all M matrices (stored transposed) or all u vectors at a given time
+    // buf size is the larger of the two
+#if PARAM_K * M_ENTRIES_BYTES * PARAM_O > BINOMIAL2(PARAM_K + 1) * M_ENTRIES_BYTES
+    uint8_t buf[PARAM_K * M_ENTRIES_BYTES * PARAM_O] = {0};
+#else
+    uint8_t buf[BINOMIAL2(PARAM_K + 1) * M_ENTRIES_BYTES] = {0};
+#endif
+    aes128ctr_ctx ctx;
+    size_t i;
+    int row, col;
+
+    // Here we use the notation from the specification document.
+    // So the parameters are in lowercase letters instead of uppercase macros.
+    // e.g. n = PARAM_N, o = PARAM_O, m = PARAM_M, etc.
+
+    // Build linear system A and target vector y minimizing temporary storage
+    // The entries of the matrices P1_j (resp. P2_j) are obtained as described in compute_P3.
+    
+    // For all i = 0, ..., k - 1, M_i is a m * o matrix defined as:
+    // M_i[j, :] = v_i^T * (P1_j + P1_j^T) * O + v_i^T * P2_j
+    // Similarly, for all i = 0, ..., k - 1 and j = k - 1, ..., i, u_i,j is a m-dimensional vector defined as:
+    // [ v_i^T * P1_a * v_j ]_{a=0}^{m-1}  if i == j
+    // [ v_i^T * P1_a * v_j + v_j^T * P1_a * v_i ]_{a=0}^{m-1}  if i != j
+    
+    // We now switch the indexing of P1_j (resp. P2_j) to P1_h (resp. P2_h) to avoid confusion.
+
+    aes128ctr_init(&ctx, seed_pk);  // initialize AES-128-CTR with seed_pk
+    // Compute v_i^T * (P1_h + P1_h^T) * O + v_i^T * P2_h and accumulate into P3_h
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = row; col < PARAM_N - PARAM_O; col++) {
+            // compute entry P1_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, &ctx);
+            // compute M and u from P1_h[row, col]
+            compute_M_from_P1(
+                // explicit cast to avoid compiler warning about pointer alignment
+                (uint8_t (*)[M_ENTRIES_BYTES * PARAM_O])buf, 
+                entry, O, V, row, col);
+        }
+    }
+    // Compute v_i^T * P2_h and accumulate into M_i
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = 0; col < PARAM_O; col++) {
+            // compute entry P2_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, &ctx);
+            // compute M from P2_h[row, col]
+            compute_M_from_P2(
+                // explicit cast to avoid compiler warning about pointer alignment
+                (uint8_t (*)[M_ENTRIES_BYTES * PARAM_O])buf,
+                entry, V, row, col);
+        }
+    }
+    // Build A from M (stored in buf)
+    build_A(A, (const uint8_t (*)[M_ENTRIES_BYTES * PARAM_O])buf);
+
+    for (i = 0; i < sizeof(buf); i++) {  // clear buf
+        buf[i] = 0;
+    }
+
+    aes128ctr_init(&ctx, seed_pk);  // initialize AES-128-CTR with seed_pk
+    // Compute v_i^T * P1_h * v_j and accumulate into u_i
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = row; col < PARAM_N - PARAM_O; col++) {
+            // compute entry P1_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, &ctx);
+            // compute u from P1_h[row, col]
+            compute_u_from_Pi(
+                // explicit cast to avoid compiler warning about pointer alignment
+                (uint8_t (*)[M_ENTRIES_BYTES])buf, 
+                entry, V, PARAM_N - PARAM_O, row, col);
+        }
+    }
+    // Build y from u (stored in buf)
+    build_y(y, (const uint8_t (*)[M_ENTRIES_BYTES])buf);
+
+    for (i = 0; i < sizeof(buf); i++) {  // clear buf
+        buf[i] = 0;
+    }
+}
+
+bool sample_solution(uint8_t x[KO_ENTRIES_BYTES],
+                     uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                     uint8_t y[M_ENTRIES_BYTES]) {
+    int i, j;
+    uint8_t full_rank;
+    
+    // At the start, x is initialized with r random vector
+    // y = y - A * r
+    for (i = 0; i < PARAM_M; i++) {
+        for (j = 0; j < PARAM_K * PARAM_O; j++) {
+            // y[i] -= A[i][j] * x[j]
+            XOR_NIBBLE(y, i, mul_f(NIBBLE(A[i], j), NIBBLE(x, j)));
+        }
+    }
+    
+    echelon_form(A, y);
+
+    // check if last row of A is zero
+    full_rank = 0;
+    for (i = 0; i < KO_ENTRIES_BYTES; i++) {
+        full_rank |= A[PARAM_M - 1][i];
+    }
+    if (full_rank == 0) {
+        return false;  // A is not full rank
+    }
+
+    backward_substitution(A, y, x);
+
+    return true;  // A is full rank and solution has been found
+}
+
+void compute_s(uint8_t s[SIG_BYTES],
+               const uint8_t x[KO_ENTRIES_BYTES],
+               const uint8_t O[O_BYTES],
+               const uint8_t V[PARAM_K * V_BYTES]) {
+    int i, row, col;
+    uint8_t e0, e1;
+
+    for (i = 0; i < SIG_BYTES; i++) {  // clear s for accumulation
+        s[i] = 0;
+    }
+
+    for (i = 0; i < PARAM_K; i++) {
+        // handle vinegar part
+        for (row = 0; row < PARAM_N - PARAM_O; row++) {
+            e0 = matrix_entry_val(V, i, row, PARAM_N - PARAM_O);  // v_i[row]
+            XOR_NIBBLE(s, i * PARAM_N + row, e0);
+        }
+        // handle oil part and x concatenation
+        for (col = 0; col < PARAM_O; col++) {
+            e0 = NIBBLE(x, i * PARAM_O + col); // x[i * PARAM_O + col]
+            XOR_NIBBLE(s, i * PARAM_N + PARAM_N - PARAM_O + col, e0);
+            for (row = 0; row < PARAM_N - PARAM_O; row++) {
+                e1 = matrix_entry_val(O, row, col, PARAM_O);  // O[row, col]
+                XOR_NIBBLE(s, i * PARAM_N + row, mul_f(e0, e1));
+            }
+        }
+    }
+}
+
+void quadratic_map(uint8_t y[M_ENTRIES_BYTES],
+                   const uint8_t s[SIG_BYTES],
+                   const uint8_t seed_pk[PK_SEED_BYTES],
+                   const uint8_t P3[P3_BYTES]) {
+    alignas(8) uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    uint8_t u[BINOMIAL2(PARAM_K + 1)][M_ENTRIES_BYTES] = {0};
+    aes128ctr_ctx ctx;
+    int row, col;
+    uint8_t *ptr;
+
+    aes128ctr_init(&ctx, seed_pk);  // initialize AES-128-CTR with seed_pk
+
+    // Compute P1_h and accumulate into u
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = row; col < PARAM_N - PARAM_O; col++) {
+            // compute entry P1_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, &ctx);
+            // accumulate into u the value s_:[row] * P1_h[row, col] * s_:[col]
+            compute_u_from_Pi(u, entry, s, PARAM_N, row, col);
+        }
+    }
+    // Compute P2_h and accumulate into u
+    for (row = 0; row < PARAM_N - PARAM_O; row++) {
+        for (col = 0; col < PARAM_O; col++) {
+            // compute entry P2_h[row, col] for all m matrices
+            aes128ctr_stream(entry, M_ENTRIES_BYTES, &ctx);
+            // accumulate into u the value s_:[row] * P2_h[row, col] * s_:[PARAM_N - PARAM_O + col]
+            compute_u_from_Pi(u, entry, s, PARAM_N, row, PARAM_N - PARAM_O + col);
+        }
+    }
+    // Use P3_h to accumulate into u
+    for (row = 0; row < PARAM_O; row++) {
+        for (col = row; col < PARAM_O; col++) {
+            // entry P3[row, col]
+            ptr = m_utmatrix_entry_ptr((uint8_t *)P3, row, col, PARAM_O);
+            memcpy(entry, ptr, M_ENTRIES_BYTES);
+            // accumulate into u the value s_:[PARAM_N - PARAM_O + row] * P3_h[row, col] * s_:[PARAM_N - PARAM_O + col]
+            compute_u_from_Pi(u, entry, s, PARAM_N, PARAM_N - PARAM_O + row, PARAM_N - PARAM_O + col);
+        }
+    }
+
+    // Build y from u
+    // clear y since build_y expects it to be initialized to t, and we want t = 0 for verification
+    memset(y, 0, M_ENTRIES_BYTES);
+    build_y(y, (const uint8_t (*)[M_ENTRIES_BYTES])u);
+}

--- a/crypto_sign/mayo1/m4stack/arithmetic.c
+++ b/crypto_sign/mayo1/m4stack/arithmetic.c
@@ -186,7 +186,7 @@ bool sample_solution(uint8_t x[KO_ENTRIES_BYTES],
     for (i = 0; i < PARAM_M; i++) {
         for (j = 0; j < PARAM_K * PARAM_O; j++) {
             // y[i] -= A[i][j] * x[j]
-            XOR_NIBBLE(y, i, mul_f(NIBBLE(A[i], j), NIBBLE(x, j)));
+            add_nibble(y, i, mul_f(nibble(A[i], j), nibble(x, j)));
         }
     }
     
@@ -221,15 +221,15 @@ void compute_s(uint8_t s[SIG_BYTES],
         // handle vinegar part
         for (row = 0; row < PARAM_N - PARAM_O; row++) {
             e0 = matrix_entry_val(V, i, row, PARAM_N - PARAM_O);  // v_i[row]
-            XOR_NIBBLE(s, i * PARAM_N + row, e0);
+            add_nibble(s, i * PARAM_N + row, e0);
         }
         // handle oil part and x concatenation
         for (col = 0; col < PARAM_O; col++) {
-            e0 = NIBBLE(x, i * PARAM_O + col); // x[i * PARAM_O + col]
-            XOR_NIBBLE(s, i * PARAM_N + PARAM_N - PARAM_O + col, e0);
+            e0 = nibble(x, i * PARAM_O + col); // x[i * PARAM_O + col]
+            add_nibble(s, i * PARAM_N + PARAM_N - PARAM_O + col, e0);
             for (row = 0; row < PARAM_N - PARAM_O; row++) {
                 e1 = matrix_entry_val(O, row, col, PARAM_O);  // O[row, col]
-                XOR_NIBBLE(s, i * PARAM_N + row, mul_f(e0, e1));
+                add_nibble(s, i * PARAM_N + row, mul_f(e0, e1));
             }
         }
     }

--- a/crypto_sign/mayo1/m4stack/arithmetic.h
+++ b/crypto_sign/mayo1/m4stack/arithmetic.h
@@ -1,0 +1,812 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2023-2025 the MAYO team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file contains some functions for arithmetic operations over GF(16)
+taken from the MAYO reference implementation. 
+These are: 
+- mul_f;
+- mul_table;
+- vec_scalarmul_u64, modified from vec_mul_add_u64;
+- echelon_form, modified from EF, but the constant-time idea is still the same;
+- back_substitution, modified from the last part of sample_solution, similarly to echelon_form;
+*/
+
+#ifndef ARITHMETIC_H
+#define ARITHMETIC_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdalign.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "params.h"
+#include "aes_ctr.h"
+#include "blocker.h"
+#include "comparison.h"
+
+#define NIBBLE(vec, pos) ((((vec)[(pos) / 2] >> (4 * ((pos) & 1))) & 0x0F))
+#define SET_NIBBLE(vec, pos, val) ((vec)[(pos) / 2] = (uint8_t)((val) << (4 * ((pos) & 1))) | (NIBBLE((vec), (pos) ^ 1) << (4 * (((pos) ^ 1) & 1))))
+#define XOR_NIBBLE(vec, pos, val) ((vec)[(pos) / 2] ^= (uint8_t)((val) << (4 * ((pos) & 1))))
+
+#define TO_BYTES(len) (((len) + 1) / 2)
+#define TO_QWORDS(bytes) (((bytes) + 7) / 8)
+
+/**
+ * Computes P3 part of the public key from seed_pk and oil_subspace.
+ * 
+ * @param[out] P3 Pointer to the output buffer for P3 of size P3_BYTES
+ * @param[in] seed_pk Pointer to the seed_pk of size PK_SEED_BYTES
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ */
+#define compute_P3 MAYO_NAMESPACE(compute_P3)
+void compute_P3(uint8_t P3[P3_BYTES],
+                const uint8_t seed_pk[PK_SEED_BYTES],
+                const uint8_t O[O_BYTES]);
+
+/**
+ * Computes L from O, P1 and P2 (generated on-the-fly with AES-128-CTR).
+ * 
+ * @param[out] L Output buffer to store L of size PARAM_M * (PARAM_N - PARAM_O) * PARAM_O / 2 bytes
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ * @param[in] P1 Pointer to the P1 part of the public key of size P1_BYTES
+ * @param[in] ctx Pointer to an initialized aes128ctr_ctx for generating P2
+ */
+#define compute_L MAYO_NAMESPACE(compute_L)
+void compute_L(uint8_t L[(PARAM_N - PARAM_O) * PARAM_O * M_ENTRIES_BYTES],
+               const uint8_t O[O_BYTES],
+               const uint8_t P1[P1_BYTES],
+               aes128ctr_ctx *ctx);
+
+/**
+ * Builds the linear system A and target vector y for signing.
+ * 
+ * @param[out] A Pointer to the linear system matrix (assumed to be zero-initialized)
+ * @param[out] y Pointer to the target vector (assumed to be initialized to t)
+ * @param[in] seed_pk Pointer to the seed_pk of size PK_SEED_BYTES
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ * @param[in] V Pointer to the vinegar variables of size PARAM_K * V_BYTES
+ */
+#define build_linear_system MAYO_NAMESPACE(build_linear_system)
+void build_linear_system(uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                         uint8_t y[M_ENTRIES_BYTES],
+                         const uint8_t seed_pk[PK_SEED_BYTES],
+                         const uint8_t O[O_BYTES],
+                         const uint8_t V[PARAM_K * V_BYTES]);
+
+/**
+ * Samples a solution x to the linear system Ax = y.
+ * 
+ * @param[out] x Pointer to the output solution vector of size KO_ENTRIES_BYTES
+ * initially set to the random vector r
+ * @param[in] A Pointer to the linear system matrix
+ * @param[in] y Pointer to the target vector
+ * @return true if a valid solution was found, false otherwise
+ */
+#define sample_solution MAYO_NAMESPACE(sample_solution)
+bool sample_solution(uint8_t x[KO_ENTRIES_BYTES],
+                     uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                     uint8_t y[M_ENTRIES_BYTES]);
+
+/**
+ * Computes the signature from the solution x, oil subspace O and vinegar variables V.
+ * 
+ * @param[out] s Pointer to the output signature of size SIG_BYTES
+ * @param[in] x Pointer to the solution vector of size KO_ENTRIES_BYTES
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ * @param[in] V Pointer to the vinegar variables of size PARAM_K * V_BYTES
+ */
+#define compute_s MAYO_NAMESPACE(compute_s)
+void compute_s(uint8_t s[SIG_BYTES],
+               const uint8_t x[KO_ENTRIES_BYTES],
+               const uint8_t O[O_BYTES],
+               const uint8_t V[PARAM_K * V_BYTES]);
+
+/**
+ * Evaluates the quadratic map to compute y from s, seed_pk, and P3,
+ * i.e. computes y = P(s) where P is the quadratic map defined by P1, P2 and P3.
+ * P1 and P2 are generated on-the-fly with AES-128-CTR using seed_pk,
+ * while P3 is given as input since it is part of the public key.
+ * 
+ * @param[out] y Pointer to the output vector of size M_ENTRIES_BYTES to store the result
+ * @param[in] s Pointer to the input signature of size SIG_BYTES
+ * @param[in] seed_pk Pointer to the seed_pk of size PK_SEED_BYTES
+ * @param[in] P3 Pointer to the P3 part of the public key of size P3_BYTES
+ */
+#define quadratic_map MAYO_NAMESPACE(quadratic_map)
+void quadratic_map(uint8_t y[M_ENTRIES_BYTES],
+                   const uint8_t s[SIG_BYTES],
+                   const uint8_t seed_pk[PK_SEED_BYTES],
+                   const uint8_t P3[P3_BYTES]);
+
+
+/**************************************************************************************
+ *   Implementation of arithmetic operations in GF(16) as static inline functions     *
+ **************************************************************************************/
+
+/**
+ * Carryless multiplication in GF(2^4) with modulus x^4 + x + 1
+ * 
+ * @param[in] a First operand (expected to be in 0..15)
+ * @param[in] b Second operand (expected to be in 0..15)
+ * @return uint8_t Result of the multiplication
+ */
+static inline uint8_t mul_f(uint8_t a, uint8_t b) {
+    // carryless multiply
+    uint8_t p;
+
+#if !(((defined(__clang__) && __clang_major__ < 15) || (!defined(__clang__) && defined(__GNUC__) && __GNUC__ <= 12)) && (defined(__x86_64__) || defined(_M_X64)))
+    a ^= uint8_t_blocker;  // prevent GCC/Clang from optimizing this code, see https://github.com/PQCMayo/MAYO-C/pull/8/changes/3dace0e22d376451fac99899cbb3252d05712995#diff-c84e4f0b977868b489bda2319658059b92f056ac5793aceba06712d2dcd13c7f
+#endif
+
+    p  = (a & 1)*b;
+    p ^= (a & 2)*b;
+    p ^= (a & 4)*b;
+    p ^= (a & 8)*b;
+
+    // reduce mod x^4 + x + 1
+    uint8_t top_p = p & 0xf0;
+    uint8_t out = (p ^ (top_p >> 4) ^ (top_p >> 3)) & 0x0f;
+    return out;
+}
+
+/**
+ * Computes the multiplicative inverse in GF(16).
+ * 
+ * @param[in] a Input element (expected to be in 0..15)
+ * @return uint8_t Multiplicative inverse of a in GF(16)
+ */
+static inline uint8_t inverse_f(uint8_t a) {
+    // multiplicative inverse in GF(16) with modulus x^4 + x + 1
+    // using exponentiation by squaring: a^(2^4 - 2) = a^14
+    uint8_t a2 = mul_f(a, a);         // a^2
+    uint8_t a4 = mul_f(a2, a2);       // a^4
+    uint8_t a8 = mul_f(a4, a4);       // a^8
+    uint8_t a12 = mul_f(a8, a4);      // a^12
+    uint8_t a14 = mul_f(a12, a2);     // a^14
+    return a14;
+}
+
+/**
+ * Retrieves an entry from a GF(16) matrix stored in a packed format.
+ * 
+ * @param[in] matrix Pointer to the matrix data (each entry is 4 bits, two entries per byte)
+ * @param[in] row Row index of the entry to retrieve
+ * @param[in] col Column index of the entry to retrieve
+ * @param[in] ncols Number of columns in the matrix
+ * @return uint8_t The retrieved matrix entry (in 0..15)
+ */
+static inline uint8_t matrix_entry_val(const uint8_t *matrix,
+                                       const int row, const int col,
+                                       const int ncols) {
+    return NIBBLE(matrix, row * ncols + col);
+}
+
+/**
+ * Retrieves a pointer to an entry of PARAM_M GF(16) elements of an full matrix stored in a packed format.
+ * 
+ * @param[in] matrix Pointer to the matrix data (each entry is M_ENTRIES_BYTES bytes)
+ * @param[in] row Row index of the entry
+ * @param[in] col Column index of the entry
+ * @param[in] ncols Number of columns in the full matrix
+ * @return uint8_t* Pointer to the byte containing the requested matrix entry
+ */
+static inline uint8_t* m_matrix_entry_ptr(uint8_t *matrix,
+                                          const int row, const int col,
+                                          const int ncols) {
+    return matrix + M_ENTRIES_BYTES * (row * ncols + col);
+}
+
+/**
+ * Retrieves a pointer to an entry of PARAM_M GF(16) elements of an upper-triangular matrix stored in a packed format.
+ * 
+ * @param[in] matrix Pointer to the matrix data (each entry is M_ENTRIES_BYTES bytes)
+ * @param[in] row Row index of the entry
+ * @param[in] col Column index of the entry
+ * @param[in] dim Number of rows/columns in the upper-triangular matrix
+ * @return uint8_t* Pointer to the byte containing the requested matrix entry
+ */
+static inline uint8_t* m_utmatrix_entry_ptr(uint8_t *matrix,
+                                            const int row, const int col,
+                                            const int dim) {
+    return matrix + M_ENTRIES_BYTES * (row * dim + col - row * (row + 1) / 2);
+}
+
+/**
+ * Precomputed multiplication table for GF(16) elements.
+ * Each byte contains four 4-bit results for multiplying by 1, 2, 4, and 8,
+ * i.e. by x^0, x^1, x^2, and x^3 in GF(16).
+ * 
+ * @param[in] b GF(16) element to multiply with (expected to be in 0..15)
+ * @return uint32_t Packed multiplication results
+ */
+static inline uint32_t mul_table(uint8_t b) {
+    uint32_t x = ((uint32_t) b) * 0x08040201;
+    uint32_t high_half = x & 0xf0f0f0f0;
+    return (x ^ (high_half >> 4) ^ (high_half >> 3));
+}
+
+/**
+ * Adds two vectors of GF(16) elements packed in uint8_t.
+ * 
+ * @param[out] out Output vector to store the result
+ * @param[in] in Input vector to add
+ * @param[in] len Length of the vectors in bytes
+ */
+static inline void vec_add_u8(uint8_t *out, const uint8_t *in, const size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        out[i] ^= in[i];
+    }
+}
+
+/**
+ * Scalarly multiplies a vector of GF(16) elements packed in uint64_t with a single GF(16) element.
+ * 
+ * @param[out] out Output vector to store the result (assumed to be aligned to 8 bytes)
+ * @param[in] outlen Length of the output vector in uint64_t elements
+ * @param[in] in Input vector to multiply of length at least outlen (assumed to be aligned to 8 bytes)
+ * @param[in] a GF(16) scalar to multiply with (expected to be in 0..15)
+ */
+static inline void vec_scalarmul_u64(uint8_t *out, const int outlen, 
+                                     const uint8_t *in, 
+                                     const uint8_t a) {
+    uint32_t tab = mul_table(a);
+    uint64_t lsb_mask = 0x1111111111111111ULL;
+    uint64_t *in_u64 = (uint64_t *)in;
+    uint64_t *out_u64 = (uint64_t *)out;
+
+    for(int i = 0; i < outlen; i++) {
+        out_u64[i] = ( in_u64[i]       & lsb_mask) * (tab & 0xf)
+                   ^ ((in_u64[i] >> 1) & lsb_mask) * ((tab >> 8)  & 0xf)
+                   ^ ((in_u64[i] >> 2) & lsb_mask) * ((tab >> 16) & 0xf)
+                   ^ ((in_u64[i] >> 3) & lsb_mask) * ((tab >> 24) & 0xf);
+    }
+}
+
+/**************************************************************************************
+ *                      Helper functions for computing P3                             *
+ **************************************************************************************/
+
+/**
+ * Computes the contribution to P3 from an entry of P1, i.e. O^T[:, row] * P1[row, col] * O[col, :].
+ * 
+ * @param[out] P3 Pointer to the output buffer for P3 of size P3_BYTES
+ * @param[in] entry Pointer to the input entry of P1, which is a vector of PARAM_M GF(16) elements 
+ * packed in uint64_t (assumed to be aligned to 8 bytes)
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ * @param[in] row Row index of the P1 entry
+ * @param[in] col Column index of the P1 entry
+ */
+static inline void compute_P3_from_P1(uint8_t P3[P3_BYTES],
+                                      const uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8],
+                                      const uint8_t O[O_BYTES],
+                                      const uint8_t row, const uint8_t col) {
+    // temporary buffers aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t tmp0[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    alignas(8) uint8_t tmp1[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    int i, j;
+    uint8_t *ptr;
+    uint8_t coeff;
+
+    for (i = 0; i < PARAM_O; i++) {
+        coeff = matrix_entry_val(O, row, i, PARAM_O);  // O^T[i, row]
+        // compute O^T[i, row] * P1[row, col]
+        vec_scalarmul_u64(tmp0, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+
+        for (j = 0; j < PARAM_O; j++) {
+            coeff = matrix_entry_val(O, col, j, PARAM_O);  // O[col, j]
+            // compute O^T[i, row] * P1[row, col] * O[col, j]
+            vec_scalarmul_u64(tmp1, TO_QWORDS(M_ENTRIES_BYTES), tmp0, coeff);
+            // accumulate into P3[i, j] the value O^T[i, row] * P1[row, col] * O[col, j]
+            ptr = m_utmatrix_entry_ptr(P3, (i <= j) ? i : j, (i <= j) ? j : i, PARAM_O);
+            vec_add_u8(ptr, tmp1, M_ENTRIES_BYTES);
+        }
+    }
+}
+
+/**
+ * Computes the contribution to P3 from an entry of P2, i.e. O^T[:, row] * P2[row, col].
+ * 
+ * @param[out] P3 Pointer to the output buffer for P3 of size P3_BYTES
+ * @param[in] entry Pointer to the input entry of P2, which is a vector of PARAM_M GF(16) elements 
+ * packed in uint64_t (assumed to be aligned to 8 bytes)
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ * @param[in] row Row index of the P2 entry
+ * @param[in] col Column index of the P2 entry
+ */
+static inline void compute_P3_from_P2(uint8_t P3[P3_BYTES],
+                                      const uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8],
+                                      const uint8_t O[O_BYTES],
+                                      const uint8_t row, const uint8_t col) {
+    // temporary buffer aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t tmp[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    int i;
+    uint8_t *ptr;
+    uint8_t coeff;
+
+    for (i = 0; i < PARAM_O; i++) {
+        coeff = matrix_entry_val(O, row, i, PARAM_O);  // O^T[i, row]
+        // compute O^T[i, row] * P2[row, col]
+        vec_scalarmul_u64(tmp, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+        // accumulate into P3[i, j] the value O^T[i, row] * P2[row, col]
+        ptr = m_utmatrix_entry_ptr(P3, (i <= col) ? i : col, (i <= col) ? col : i, PARAM_O);
+        vec_add_u8(ptr, tmp, M_ENTRIES_BYTES);
+    }
+}
+
+/**************************************************************************************
+ *                 Helper functions for computing L, M and u                          *
+ **************************************************************************************/
+
+/**
+ * Computes the contribution to L from an entry of P1, 
+ * i.e. P1[row, col] * O[col, :] and P1^T[col, row] * O[row, :].
+ * 
+ * @param[out] L Output buffer to store L of size L_BYTES
+ * @param[in] entry Pointer to the input entry of P1, which is a vector of PARAM_M GF(16) elements
+ * packed in uint64_t (assumed to be aligned to 8 bytes)
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ * @param[in] row Row index of the P1 entry
+ * @param[in] col Column index of the P1 entry
+ */
+static inline void compute_L_from_P1(uint8_t L[L_BYTES],
+                                     const uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8],
+                                     const uint8_t O[O_BYTES],
+                                     const uint8_t row, const uint8_t col) {
+    // temporary buffer aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t tmp[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    int i;
+    uint8_t *ptr;
+    uint8_t coeff;
+
+    if (row == col) {
+        return;  // no contribution to L from the diagonal entries of P1
+    }
+    for (i = 0; i < PARAM_O; i++) {
+        coeff = matrix_entry_val(O, col, i, PARAM_O);  // O[col, i]
+        // compute P1[row, col] * O[col, i]
+        vec_scalarmul_u64(tmp, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+        // accumulate into L[row, i] the value P1[row, col] * O[col, i]
+        ptr = m_matrix_entry_ptr(L, row, i, PARAM_O);
+        vec_add_u8(ptr, tmp, M_ENTRIES_BYTES);
+
+        coeff = matrix_entry_val(O, row, i, PARAM_O);  // O[row, i]
+        // compute P1^T[col, row] * O[row, i]
+        vec_scalarmul_u64(tmp, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+        // accumulate into L[col, i] the value P1^T[col, row] * O[row, i]
+        ptr = m_matrix_entry_ptr(L, col, i, PARAM_O);
+        vec_add_u8(ptr, tmp, M_ENTRIES_BYTES);
+    }
+}
+
+#define U_INDEX_AUX(i, j) ((i) * PARAM_K - (i) * ((i) - 1) / 2 + PARAM_K - (j) - 1)
+// Determine the ell value in the signature/verification loop from i and j
+#define U_INDEX(i, j) (U_INDEX_AUX(((i) <= (j) ? (i) : (j)), ((i) <= (j) ? (j) : (i))))
+
+/**
+ * Computes the contribution to M from a given entry of the matrix P1, 
+ * i.e. v_i[row] * P1[row, col] * O[col, :] and v_i[col] * P1^T[col, row] * O[row, :].
+ * 
+ * @param[out] M Output matrix M to store the result
+ * @param[in] entry Input entry of the matrix P1 (PARAM_M GF(16) elements packed in uint64_t)
+ * @param[in] O Pointer to the oil subspace of size O_BYTES
+ * @param[in] V Pointer to the vinegar variables of size M * V_BYTES
+ * @param[in] row Row index of the entry
+ * @param[in] col Column index of the entry
+ */
+static inline void compute_M_from_P1(uint8_t M[PARAM_K][M_ENTRIES_BYTES * PARAM_O],
+                                     const uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8],
+                                     const uint8_t O[O_BYTES], const uint8_t V[PARAM_K * V_BYTES],
+                                     const uint8_t row, const uint8_t col) {
+    // temporary buffers aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t tmp0[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    alignas(8) uint8_t tmp1[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    int i, j;
+    uint8_t coeff;
+    uint8_t *ptr;
+
+    if (row == col) {
+        return;  // skip computation since the diagonal of P1 + P1^T is zero
+    }
+    for (i = 0; i < PARAM_K; i++) {
+        // Handle v_i^T * P1 * O
+        coeff = matrix_entry_val(V, i, row, PARAM_N - PARAM_O);  // v_i[row]
+        // compute v_i[row] * P1[row, col]
+        vec_scalarmul_u64(tmp0, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+        for (j = 0; j < PARAM_O; j++) {
+            coeff = matrix_entry_val(O, col, j, PARAM_O);  // O[col, j]
+            vec_scalarmul_u64(tmp1, TO_QWORDS(M_ENTRIES_BYTES), tmp0, coeff);
+            // accumulate into M_i the value v_i[row] * P1[row, col] * O[col, j]
+            ptr = m_matrix_entry_ptr((uint8_t *)M, i, j, PARAM_O);
+            vec_add_u8(ptr, tmp1, M_ENTRIES_BYTES);
+        }
+        
+        // Handle v_i^T * P1^T * O
+        coeff = matrix_entry_val(V, i, col, PARAM_N - PARAM_O);  // v_i[col]
+        // compute v_i[col] * P1^T[col, row]
+        vec_scalarmul_u64(tmp0, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+        for (j = 0; j < PARAM_O; j++) {
+            coeff = matrix_entry_val(O, row, j, PARAM_O);  // O[row, j]
+            vec_scalarmul_u64(tmp1, TO_QWORDS(M_ENTRIES_BYTES), tmp0, coeff);
+            // accumulate into M_i the value v_i[col] * P1^T[col, row] * O[row, j]
+            ptr = m_matrix_entry_ptr((uint8_t *)M, i, j, PARAM_O);
+            vec_add_u8(ptr, tmp1, M_ENTRIES_BYTES);
+        }
+    }
+}
+
+/**
+ * Computes M from a given entry of the matrix P2.
+ * 
+ * @param[out] M Output matrix M to store the result
+ * @param[in] entry Input entry of the matrix P2 (PARAM_M GF(16) elements packed in uint64_t)
+ * @param[in] V Pointer to the vinegar variables of size M * V_BYTES
+ * @param[in] row Row index of the entry
+ * @param[in] col Column index of the entry
+ */
+static inline void compute_M_from_P2(uint8_t M[PARAM_K][M_ENTRIES_BYTES * PARAM_O],
+                                     const uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8],
+                                     const uint8_t V[PARAM_K * V_BYTES],
+                                     const uint8_t row, const uint8_t col) {
+    // temporary buffer aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t tmp[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    int i;
+    uint8_t coeff;
+    uint8_t *ptr;
+
+    for (i = 0; i < PARAM_K; i++) {
+        coeff = matrix_entry_val(V, i, row, PARAM_N - PARAM_O);  // v_i[row]
+        // compute v_i[row] * P2[row, col]
+        vec_scalarmul_u64(tmp, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+        // see M as a matrix with entries of M_ENTRIES_BYTES bytes
+        ptr = m_matrix_entry_ptr((uint8_t *)M, i, col, PARAM_O);
+        // accumulate tmp into M_i[:, col]
+        vec_add_u8(ptr, tmp, M_ENTRIES_BYTES);
+    }
+}
+
+/**
+ * Computes u from a given entry of the matrix Pk, i.e. P1, P2 or P3.
+ * 
+ * @param[out] u Output vector u to store the result
+ * @param[in] entry Input entry of the matrix Pk (PARAM_M GF(16) elements packed in uint64_t)
+ * @param[in] W Pointer to a matrix with PARAM_K columns, and usually 
+ * PARAM_N - PARAM_O rows if they are vinegar variables, or
+ * PARAM_N rows if they are signature variables
+ * @param[in] W_ncols Number of columns in W
+ * @param[in] row Row index of the entry
+ * @param[in] col Column index of the entry
+ */
+static inline void compute_u_from_Pi(uint8_t u[BINOMIAL2(PARAM_K + 1)][M_ENTRIES_BYTES],
+                                     const uint8_t entry[TO_QWORDS(M_ENTRIES_BYTES) * 8],
+                                     const uint8_t *W, const int W_ncols,
+                                     const uint8_t row, const uint8_t col) {
+    // temporary buffers aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t tmp0[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    alignas(8) uint8_t tmp1[TO_QWORDS(M_ENTRIES_BYTES) * 8];
+    int i, j, ell;
+    uint8_t coeff;
+
+    for (i = 0; i < PARAM_K; i++) {
+        coeff = matrix_entry_val(W, i, row, W_ncols);  // v_i[row]
+        // compute v_i[row] * Pk[row, col]
+        vec_scalarmul_u64(tmp0, TO_QWORDS(M_ENTRIES_BYTES), entry, coeff);
+        // accumulate into u[ell] the value v_i^T * Pk * v_j
+        for (j = 0; j < PARAM_K; j++) {
+            coeff = matrix_entry_val(W, j, col, W_ncols);  // v_j[col]
+            // compute v_i[row] * Pk[row, col] * v_j[col]
+            vec_scalarmul_u64(tmp1, TO_QWORDS(M_ENTRIES_BYTES), tmp0, coeff);
+            // accumulate into u[ell]
+            ell = U_INDEX(i, j);
+            vec_add_u8(u[ell], tmp1, M_ENTRIES_BYTES);
+        }
+    }
+}
+
+/**************************************************************************************
+ *           Helper functions for building the linear system from M and u             *
+ **************************************************************************************/
+
+/**
+ * Multiplies A by z, where the columns of A are seen as polynomials mod f(z).
+ * 
+ * @param[in,out] A Input/output matrix A
+ */
+static inline void A_mul_z(uint8_t A[PARAM_M][KO_ENTRIES_BYTES]) {
+    int row, col;
+    // temporary buffers aligned to 8 bytes as required by vec_scalarmul_u64
+    alignas(8) uint8_t tmp0[TO_QWORDS(KO_ENTRIES_BYTES) * 8];
+    alignas(8) uint8_t tmp1[TO_QWORDS(KO_ENTRIES_BYTES) * 8];
+    // shift A up by one
+    for (col = 0; col < KO_ENTRIES_BYTES; col++) {  // copy last row of A to tmp0
+        tmp0[col] = A[PARAM_M - 1][col];
+    }
+    for (row = PARAM_M - 1; row > 0; row--) {  // shift A up by one
+        for (col = 0; col < KO_ENTRIES_BYTES; col++) {
+            A[row][col] = A[row - 1][col];
+        }
+    }
+    for (col = 0; col < KO_ENTRIES_BYTES; col++) {  // clear first row of A
+        A[0][col] = 0;
+    }
+    // add the contribution of the modulus
+    vec_scalarmul_u64(tmp1, TO_QWORDS(KO_ENTRIES_BYTES), tmp0, F_TAIL0);
+    vec_add_u8(A[0], tmp1, KO_ENTRIES_BYTES);
+    vec_scalarmul_u64(tmp1, TO_QWORDS(KO_ENTRIES_BYTES), tmp0, F_TAIL1);
+    vec_add_u8(A[1], tmp1, KO_ENTRIES_BYTES);
+    vec_scalarmul_u64(tmp1, TO_QWORDS(KO_ENTRIES_BYTES), tmp0, F_TAIL2);
+    vec_add_u8(A[2], tmp1, KO_ENTRIES_BYTES);
+    vec_scalarmul_u64(tmp1, TO_QWORDS(KO_ENTRIES_BYTES), tmp0, F_TAIL3);
+    vec_add_u8(A[3], tmp1, KO_ENTRIES_BYTES);
+}
+
+/**
+ * Accumulates the contributions of M_i and M_j into the matrix A.
+ * 
+ * @param[out] A Output matrix A
+ * @param[in] M Input matrices M
+ * @param[in] i Index i of M
+ * @param[in] j Index j of M
+ */
+static inline void A_add_M(uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                           const uint8_t M[PARAM_K][M_ENTRIES_BYTES * PARAM_O],
+                           const int i, const int j) {
+    int row, col;
+    uint8_t coeff;
+
+    // accumulate M_j into A
+    for (row = 0; row < PARAM_M; row++) {
+        for (col = 0; col < PARAM_O; col++) {
+            // M_j[row, col] (M is stored transposed)
+            coeff = matrix_entry_val(M[j], col, row, PARAM_M);
+            XOR_NIBBLE(A[row], i * PARAM_O + col, coeff);
+        }
+    }
+    if (i == j) {
+        return;  // skip accumulation of M_i since it would be added twice otherwise
+    }
+    // accumulate M_i into A
+    for (row = 0; row < PARAM_M; row++) {
+        for (col = 0; col < PARAM_O; col++) {
+            // M_i[row, col] (M is stored transposed)
+            coeff = matrix_entry_val(M[i], col, row, PARAM_M);
+            XOR_NIBBLE(A[row], j * PARAM_O + col, coeff);
+        }
+    }
+}
+
+/**
+ * Builds the matrix A from the matrices M.
+ * 
+ * @param[out] A Output matrix A (assumed to be zero-initialized)
+ * @param[in] M Input matrices M
+ */
+static inline void build_A(uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                           const uint8_t M[PARAM_K][M_ENTRIES_BYTES * PARAM_O]) {
+    int i, j;
+    
+    // Build A from maximum ell to minimum ell
+    A_add_M(A, M, PARAM_K - 1, PARAM_K - 1);  // maximum ell
+    // for all ell from second maximum to minimum
+    for (i = PARAM_K - 2; i >= 0; i--) {
+        for (j = i; j < PARAM_K; j++) {
+            // multiply by z mod f(z)
+            A_mul_z(A);
+            // accumulate M into A
+            A_add_M(A, M, i, j);
+        }
+    }
+}
+
+/**
+ * Multiplies y by z mod f(z).
+ * 
+ * @param[in,out] y Input/output vector y
+ */
+static inline void y_mul_z(uint8_t y[M_ENTRIES_BYTES]) {
+    int i;
+    uint8_t last;
+
+    last = y[M_ENTRIES_BYTES - 1] >> 4;  // get last GF(16) element of y
+    // shift y down by one GF(16) element
+    for (i = M_ENTRIES_BYTES - 1; i > 0; i--) {
+        y[i] = (y[i] << 4) | (y[i - 1] >> 4);
+    }
+    y[0] = (y[0] << 4);
+    // add the contribution of the modulus
+    y[0] ^= (mul_f(last, F_TAIL0) | (mul_f(last, F_TAIL1) << 4));
+    y[1] ^= (mul_f(last, F_TAIL2) | (mul_f(last, F_TAIL3) << 4));
+}
+
+/**
+ * Builds the target vector y from the vectors u.
+ * 
+ * @param[out] y Output target vector y (assumed to be initialized to t)
+ * @param[in] u Input vectors u
+ */
+static inline void build_y(uint8_t y[M_ENTRIES_BYTES],
+                           const uint8_t u[BINOMIAL2(PARAM_K + 1)][M_ENTRIES_BYTES]) {
+    uint8_t t[M_ENTRIES_BYTES];  // holds the target vector y initial value
+    int i, j, ell;
+
+    // No leak since the value of y is public
+    memcpy(t, y, M_ENTRIES_BYTES);  // copy initial value of target vector y
+    memset(y, 0, M_ENTRIES_BYTES);  // clear y to accumulate into it
+
+    // Build y from maximum ell to minimum ell
+    ell = U_INDEX(PARAM_K - 1, PARAM_K - 1);
+    vec_add_u8(y, u[ell], M_ENTRIES_BYTES);  // accumulate u[ell_max] into y
+    // for all ell from second maximum to minimum
+    for (i = PARAM_K - 2; i >= 0; i--) {
+        for (j = i; j < PARAM_K; j++) {
+            // multiply by z mod f(z)
+            y_mul_z(y);
+            // accumulate u[ell] into y
+            ell = U_INDEX(i, j);
+            vec_add_u8(y, u[ell], M_ENTRIES_BYTES);
+        }
+    }
+    // finally add the initial value t
+    vec_add_u8(y, t, M_ENTRIES_BYTES);
+}
+
+/**************************************************************************************
+ *           Implementation of Gaussian elimination in constant-time                  *
+ **************************************************************************************/
+
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+/**
+ * Transforms the augmented matrix [A | y] into echelon form using Gaussian elimination
+ * in constant-time.
+ * 
+ * @param[in,out] A Input/output matrix A
+ * @param[in,out] y Input/output target vector y
+ */
+static inline void echelon_form(uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                                uint8_t y[M_ENTRIES_BYTES]) {
+    alignas(8) uint8_t tmp0[TO_QWORDS(KO_ENTRIES_BYTES + 1) * 8];
+    alignas(8) uint8_t tmp1[TO_QWORDS(KO_ENTRIES_BYTES + 1) * 8];
+    int row, byte;  // row and byte indices
+    int pivot_row, pivot_col;
+    // lower and upper bounds for pivot row at each step
+    int pivot_row_lb, pivot_row_ub;
+    uint8_t pivot, pivot_inv;
+    
+    pivot_row = 0;
+    for (pivot_col = 0; pivot_col < PARAM_K * PARAM_O; pivot_col++) {        
+        // the pivot row is between these bounds if A has full rank
+        pivot_row_lb = MAX(0, pivot_col + PARAM_M - PARAM_K * PARAM_O - 1);
+        pivot_row_ub = MIN(PARAM_M - 1, pivot_col);
+
+        // clear tmp0 and tmp1
+        for (byte = 0; byte < KO_ENTRIES_BYTES + 1; byte++) {
+            tmp0[byte] = 0;
+            tmp1[byte] = 0;
+        }
+
+        // Iterate to find a pivot row considering at most 32 rows after the upper bound
+        // since the probability of not finding a pivot after 32 rows is negligible (2^-128 for q = 16).
+        // The pivot row is contained in tmp0 at the end of this loop
+        uint8_t pivot_is_zero = 0xFF;
+        pivot = 0;  // avoid compiler warning
+        for (row = pivot_row_lb; row <= MIN(PARAM_M - 1, pivot_row_ub + 32); row++) {
+            // The idea is to conditionally add the candidate pivot row into tmp0:
+            // - if it is the current pivot_row, or 
+            // - if we have not found a pivot yet and the index is below row,
+            //   i.e. the left entries, w.r.t. pivot_col, of the row are all zero.
+            // We continue this process until we find a nonzero pivot, then we
+            // do not add any more rows, even if we don't stop the loop.
+            // Then tmp0 will contain the sum of all these rows, with a nonzero pivot.
+
+            uint8_t is_pivot_row = ~ct_compare_32(row, pivot_row);
+            uint8_t below_pivot_row = ct_is_greater_than(row, pivot_row);
+            
+            // conditionally add row into tmp0
+            for (byte = 0; byte < KO_ENTRIES_BYTES; byte++) {
+                tmp0[byte] ^= A[row][byte] &
+                    (is_pivot_row | (below_pivot_row & pivot_is_zero));
+            }
+            tmp0[KO_ENTRIES_BYTES] ^= NIBBLE(y, row) &
+                (is_pivot_row | (below_pivot_row & pivot_is_zero));
+
+            // update pivot_is_zero
+            pivot = NIBBLE(tmp0, pivot_col);
+            pivot_is_zero = ~ct_compare_8(pivot, 0);
+        }
+
+        // multiply pivot row by inverse of pivot and store in tmp1
+        pivot_inv = inverse_f(pivot);
+        vec_scalarmul_u64(tmp1, TO_QWORDS(KO_ENTRIES_BYTES + 1), tmp0, pivot_inv);
+
+        // conditionally write pivot row to the correct row, i.e. pivot_row,
+        // if the pivot is non-zero
+        for (row = pivot_row_lb; row <= pivot_row_ub; row++) {
+            uint8_t do_copy = ~ct_compare_32(row, pivot_row) & ~pivot_is_zero;
+            uint8_t do_not_copy = ~do_copy;
+            for (byte = 0; byte < KO_ENTRIES_BYTES; byte++) {
+                A[row][byte] = (do_not_copy & A[row][byte]) + (do_copy & tmp1[byte]);
+            }
+            uint8_t new_nibble = (do_not_copy & NIBBLE(y, row)) + 
+                (do_copy & NIBBLE(tmp1, PARAM_K * PARAM_O));
+            SET_NIBBLE(y, row, new_nibble);
+        }
+
+        // eliminate entries below pivot
+        for (row = pivot_row_lb; row < PARAM_M; row++) {
+            // negate comparison result to get 1 if row < pivot_row, 0 otherwise
+            uint8_t below_pivot = -ct_is_greater_than(row, pivot_row);
+            uint8_t elt_to_elim = NIBBLE(A[row], pivot_col);
+            vec_scalarmul_u64(tmp0, TO_QWORDS(KO_ENTRIES_BYTES + 1), tmp1, below_pivot * elt_to_elim);
+            vec_add_u8(A[row], tmp0, KO_ENTRIES_BYTES);
+            XOR_NIBBLE(y, row, NIBBLE(tmp0, PARAM_K * PARAM_O));
+        }
+
+        // update pivot_row, i.e. increment iff pivot is non-zero
+        pivot_row += (-(int8_t)(~pivot_is_zero));
+    }
+}
+
+/**
+ * Solves the upper-triangular system A * x = y using backward substitution
+ * in constant-time.
+ * 
+ * @param[in] A Input upper-triangular matrix A
+ * @param[in] y Input target vector y (its value will be modified during the computation)
+ * @param[out] x Output solution vector x initialised with a randomized initial value
+ */
+static inline void backward_substitution(uint8_t A[PARAM_M][KO_ENTRIES_BYTES],
+                                         uint8_t y[M_ENTRIES_BYTES],
+                                         uint8_t x[KO_ENTRIES_BYTES]) {
+    int i;
+    int row, col;
+    int column_ub;
+    uint8_t finished;
+    uint8_t correct_column;
+    uint8_t first_nonzero;
+
+    for (row = PARAM_M - 1; row >= 0; row--) {
+        finished = 0;  // indicates whether we have found the first non-zero column in this row
+
+        // The first nonzero entry in row r is between r and k*o.
+        // We can limit the search to r + 32, and we will still find it
+        // except with probability q^-32 (for q = 16 we have 2^-128 probability of failure).
+        column_ub = MIN(PARAM_K * PARAM_O, row + 32);
+
+        // find first non-zero column in row in constant-time
+        for (col = row; col < column_ub; col++) {
+            // Compare two bytes in constant time.
+            correct_column = ct_compare_8(NIBBLE(A[row], col), 0) & ~finished;
+            first_nonzero = correct_column & NIBBLE(y, row);
+
+            // x[col] += first_nonzero
+            XOR_NIBBLE(x, col, first_nonzero);
+            // y -= first_nonzero * A[:, col]
+            for (i = 0; i < row; i++) {
+                XOR_NIBBLE(y, i, mul_f(first_nonzero, NIBBLE(A[i], col)));
+            }
+            
+            // mark as finished if we found the first non-zero column
+            finished = finished | correct_column;
+        }
+    }
+}
+
+#endif  // ARITHMETIC_H

--- a/crypto_sign/mayo1/m4stack/blocker.c
+++ b/crypto_sign/mayo1/m4stack/blocker.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "blocker.h"
+
+// Set the blocker variables to zero
+volatile uint8_t uint8_t_blocker_variable = 0;
+volatile uint32_t uint32_t_blocker_variable = 0;
+volatile uint64_t uint64_t_blocker_variable = 0;

--- a/crypto_sign/mayo1/m4stack/blocker.h
+++ b/crypto_sign/mayo1/m4stack/blocker.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BLOCKER_H
+#define BLOCKER_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "config.h"
+
+// Variables to prevent certain compiler optimizations
+// see https://github.com/PQCMayo/MAYO-C/pull/8/changes/3dace0e22d376451fac99899cbb3252d05712995#diff-c84e4f0b977868b489bda2319658059b92f056ac5793aceba06712d2dcd13c7f
+extern volatile uint8_t uint8_t_blocker_variable;
+extern volatile uint32_t uint32_t_blocker_variable;
+extern volatile uint64_t uint64_t_blocker_variable;
+
+#if USE_BLOCKERS == 1
+#define uint8_t_blocker uint8_t_blocker_variable
+#define uint32_t_blocker uint32_t_blocker_variable
+#define uint64_t_blocker uint64_t_blocker_variable
+#elif USE_BLOCKERS == 0
+#define uint8_t_blocker 0
+#define uint32_t_blocker 0
+#define uint64_t_blocker 0
+#else
+#error "Invalid value for USE_BLOCKERS, expected 0 or 1"
+#endif
+
+#endif  // BLOCKER_H

--- a/crypto_sign/mayo1/m4stack/comparison.h
+++ b/crypto_sign/mayo1/m4stack/comparison.h
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2023-2025 the MAYO team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+The following costant-time comparisons are directly taken from the MAYO
+reference implementation, and adapted to be used in this project. The original code can be found
+in arithmetic.h.
+*/
+
+#ifndef COMPARISON_H
+#define COMPARISON_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "blocker.h"
+
+#if !(((!defined(__clang__) && defined(__GNUC__) && __GNUC__ <= 12)) && (defined(__x86_64__) || defined(_M_X64)))
+// a > b -> b - a is negative
+// returns 0xFFFFFFFF if true, 0x00000000 if false
+static uint32_t ct_is_greater_than(int a, int b) {
+    int32_t diff = b - a;
+    return ((uint32_t) (diff >> (8*sizeof(uint32_t)-1)) ^ uint32_t_blocker);
+}
+
+// a > b -> b - a is negative
+// returns 0xFFFFFFFFFFFFFFFF if true, 0x0000000000000000 if false
+static inline uint64_t ct_64_is_greater_than(int a, int b) {
+    int64_t diff = ((int64_t) b) - ((int64_t) a);
+    return ((uint64_t) (diff >> (8*sizeof(uint64_t)-1)) ^ uint64_t_blocker);
+}
+
+// if a == b -> 0x00000000, else 0xFFFFFFFF
+static inline uint32_t ct_compare_32(int a, int b) {
+    return ((uint32_t)((-(int32_t)(a ^ b)) >> (8*sizeof(uint32_t)-1)) ^ uint32_t_blocker);
+}
+
+// if a == b -> 0x0000000000000000, else 0xFFFFFFFFFFFFFFFF
+static inline uint64_t ct_compare_64(int a, int b) {
+    return ((uint64_t)((-(int64_t)(a ^ b)) >> (8*sizeof(uint64_t)-1)) ^ uint64_t_blocker);
+}
+
+// if a == b -> 0x00, else 0xFF
+static inline uint8_t ct_compare_8(uint8_t a, uint8_t b) {
+    return ((int8_t)((-(int32_t)(a ^ b)) >> (8*sizeof(uint32_t)-1)) ^ uint8_t_blocker);
+}
+#else
+// a > b -> b - a is negative
+// returns 0xFFFFFFFF if true, 0x00000000 if false
+static inline uint32_t ct_is_greater_than(int a, int b) {
+    int32_t diff = b - a;
+    return ((uint32_t) (diff >> (8*sizeof(uint32_t)-1)));
+}
+
+// a > b -> b - a is negative
+// returns 0xFFFFFFFF if true, 0x00000000 if false
+static inline uint64_t ct_64_is_greater_than(int a, int b) {
+    int64_t diff = ((int64_t) b) - ((int64_t) a);
+    return ((uint64_t) (diff >> (8*sizeof(uint64_t)-1)));
+}
+
+// if a == b -> 0x00000000, else 0xFFFFFFFF
+static inline uint32_t ct_compare_32(int a, int b) {
+    return ((uint32_t)((-(int32_t)(a ^ b)) >> (8*sizeof(uint32_t)-1)));
+}
+
+// if a == b -> 0x0000000000000000, else 0xFFFFFFFFFFFFFFFF
+static inline uint64_t ct_compare_64(int a, int b) {
+    return ((uint64_t)((-(int64_t)(a ^ b)) >> (8*sizeof(uint64_t)-1)));
+}
+
+// if a == b -> 0x00, else 0xFF
+static inline uint8_t ct_compare_8(uint8_t a, uint8_t b) {
+    return ((int8_t)((-(int32_t)(a ^ b)) >> (8*sizeof(uint32_t)-1)));
+}
+#endif
+
+#endif  // COMPARISON_H

--- a/crypto_sign/mayo1/m4stack/comparison.h
+++ b/crypto_sign/mayo1/m4stack/comparison.h
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 /*
-The following costant-time comparisons are directly taken from the MAYO
+The following constant-time comparisons are directly taken from the MAYO
 reference implementation, and adapted to be used in this project. The original code can be found
 in arithmetic.h.
 */
@@ -33,7 +33,7 @@ in arithmetic.h.
 #if !(((!defined(__clang__) && defined(__GNUC__) && __GNUC__ <= 12)) && (defined(__x86_64__) || defined(_M_X64)))
 // a > b -> b - a is negative
 // returns 0xFFFFFFFF if true, 0x00000000 if false
-static uint32_t ct_is_greater_than(int a, int b) {
+static inline uint32_t ct_is_greater_than(int a, int b) {
     int32_t diff = b - a;
     return ((uint32_t) (diff >> (8*sizeof(uint32_t)-1)) ^ uint32_t_blocker);
 }

--- a/crypto_sign/mayo1/m4stack/config.h
+++ b/crypto_sign/mayo1/m4stack/config.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+The structure of this file is inspired by https://github.com/pq-crystals/dilithium.git
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#ifndef MAYO_RANDOMIZED_SIGNING
+#define MAYO_RANDOMIZED_SIGNING 1
+#endif
+
+#if MAYO_RANDOMIZED_SIGNING != 0 && MAYO_RANDOMIZED_SIGNING != 1
+#error "MAYO_RANDOMIZED_SIGNING must be either 0 or 1"
+#endif
+
+#ifndef MAYO_MODE
+#define MAYO_MODE 1
+#endif
+
+#if MAYO_MODE == 1
+#define CRYPTO_ALGNAME "MAYO_1"
+#define MAYO_NAMESPACETOP mayo1
+#define MAYO_NAMESPACE(s) mayo1_##s
+#elif MAYO_MODE == 2
+#define CRYPTO_ALGNAME "MAYO_2"
+#define MAYO_NAMESPACETOP mayo2
+#define MAYO_NAMESPACE(s) mayo2_##s
+#elif MAYO_MODE == 3
+#define CRYPTO_ALGNAME "MAYO_3"
+#define MAYO_NAMESPACETOP mayo3
+#define MAYO_NAMESPACE(s) mayo3_##s
+#elif MAYO_MODE == 5
+#define CRYPTO_ALGNAME "MAYO_5"
+#define MAYO_NAMESPACETOP mayo5
+#define MAYO_NAMESPACE(s) mayo5_##s
+#else
+#error "Unsupported MAYO_MODE"
+#endif // MAYO_MODE
+
+#ifndef USE_BLOCKERS
+#define USE_BLOCKERS 1
+#endif
+
+#if USE_BLOCKERS != 0 && USE_BLOCKERS != 1
+#error "USE_BLOCKERS must be either 0 or 1"
+#endif
+
+#endif  // CONFIG_H

--- a/crypto_sign/mayo1/m4stack/mayo.c
+++ b/crypto_sign/mayo1/m4stack/mayo.c
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// standard headers
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+// project headers
+#include <mayo.h>
+#include <randombytes.h>
+// local headers
+#include "params.h"
+#include "fips202.h"
+#include "aes_ctr.h"
+#include "arithmetic.h"
+
+int mayo_keypair_internal(uint8_t *pk, uint8_t *seed_sk) {
+    // contiguous buffer for seed_pk and oil_subspace
+    uint8_t buf[PK_SEED_BYTES + O_BYTES];
+
+    // derive seed_pk and oil_subspace from seed_sk
+    shake256(buf, PK_SEED_BYTES + O_BYTES, seed_sk, SK_SEED_BYTES);
+
+    // copy seed_pk to pk
+    memcpy(pk, buf, PK_SEED_BYTES);
+    // zero initialize P3 part of the public key
+    memset(pk + PK_SEED_BYTES, 0, P3_BYTES);
+
+    // compute P3 part of the public key
+    compute_P3(pk + PK_SEED_BYTES, buf, buf + PK_SEED_BYTES);
+
+    // clear sensitive data
+    memset(buf, 0, sizeof(buf));
+
+    return MAYO_OK;
+}
+
+int mayo_keypair(uint8_t *pk, uint8_t *sk) {
+    uint8_t seed_sk[SK_SEED_BYTES];
+
+    // pick seed_sk securely at random
+    if (randombytes(seed_sk, SK_SEED_BYTES) != 0) {
+        return MAYO_ERR;  // error in randomness source
+    }
+
+    // generate keypair from seed_sk
+    mayo_keypair_internal(pk, seed_sk);
+
+    // copy seed_sk to sk
+    memcpy(sk, seed_sk, SK_SEED_BYTES);
+
+    // clear sensitive data
+    memset(seed_sk, 0, SK_SEED_BYTES);
+
+    return MAYO_OK;
+}
+
+int mayo_expand_pk(uint8_t *epk, const uint8_t *cpk) {
+    aes128ctr_ctx ctx;
+    aes128ctr_init(&ctx, cpk);  // initialize AES-128-CTR with seed_pk
+    aes128ctr_stream(epk, P1_BYTES + P2_BYTES, &ctx);  // generate P1 and P2
+    memcpy(epk + P1_BYTES + P2_BYTES, cpk + PK_SEED_BYTES, P3_BYTES);  // copy P3
+    return MAYO_OK;
+}
+
+int mayo_expand_sk(uint8_t *esk, const uint8_t *csk) {
+    uint8_t buf[PK_SEED_BYTES + O_BYTES];  // contiguous buffer for seed pk and oil subspace
+    aes128ctr_ctx ctx;
+    
+    // append seed_sk to esk
+    memcpy(esk, csk, SK_SEED_BYTES);
+
+    // derive seed_pk and oil_subspace from seed_sk
+    shake256(buf, PK_SEED_BYTES + O_BYTES, csk, SK_SEED_BYTES);
+    // append O to esk
+    memcpy(esk + SK_SEED_BYTES, buf + PK_SEED_BYTES, O_BYTES);
+
+    // generate P1 using AES-128-CTR with seed_pk
+    aes128ctr_init(&ctx, buf);  // initialize AES-128-CTR with seed_pk
+    aes128ctr_stream(esk + SK_SEED_BYTES + O_BYTES, P1_BYTES, &ctx);  // generate P1
+
+    // compute L using O, P1 and P2 (generated on-the-fly with AES-128-CTR)
+    compute_L(esk + SK_SEED_BYTES + O_BYTES + P1_BYTES,
+              buf + PK_SEED_BYTES,
+              esk + SK_SEED_BYTES + O_BYTES,
+              &ctx);
+    
+    // clear sensitive data
+    memset(buf, 0, sizeof(buf));
+    memset(&ctx, 0, sizeof(ctx));
+
+    return MAYO_OK;
+}
+
+int mayo_sign_signature_internal(uint8_t *sig, size_t *siglen,
+                                 const uint8_t *m, size_t mlen,
+                                 const uint8_t rnd[R_BYTES],
+                                 const uint8_t *sk) {
+    int ctr;
+    uint8_t buf[PK_SEED_BYTES + O_BYTES];  // contiguous buffer for seed pk and oil subspace
+    // contiguous buffer for message digest, salt (or randomness), seed_sk and counter
+    uint8_t tmp[DIGEST_BYTES + SALT_BYTES + SK_SEED_BYTES + 1];
+    
+    // vinegar variables and r (after sample_solution the solution x is in place of r)
+    uint8_t V[PARAM_K * V_BYTES + KO_ENTRIES_BYTES];
+    uint8_t A[PARAM_M][KO_ENTRIES_BYTES] = {0};  // linear system matrix
+    uint8_t y[M_ENTRIES_BYTES];  // linear system target vector (initialized to t)
+    
+    // derive seed pk and oil subspace from seed_sk
+    shake256(buf, PK_SEED_BYTES + O_BYTES, sk, SK_SEED_BYTES);
+
+    // compute message digest
+    shake256(tmp, DIGEST_BYTES, m, mlen);
+    // append randomness and seed_sk
+    memcpy(tmp + DIGEST_BYTES, rnd, R_BYTES);
+    memcpy(tmp + DIGEST_BYTES + R_BYTES, sk, SK_SEED_BYTES);
+    // compute salt (overlapping buffer, works for this implementation of shake256)
+    shake256(tmp + DIGEST_BYTES, SALT_BYTES, tmp, DIGEST_BYTES + R_BYTES + SK_SEED_BYTES);
+    
+    // fiat-shamir with aborts
+    for (ctr = 0; ctr < 256; ctr++) {
+        // derive vinegar variables and r
+        tmp[DIGEST_BYTES + SALT_BYTES + SK_SEED_BYTES] = (uint8_t)ctr;
+        shake256(V, 
+                 PARAM_K * V_BYTES + KO_ENTRIES_BYTES, 
+                 tmp, 
+                 DIGEST_BYTES + SALT_BYTES + SK_SEED_BYTES + 1);
+        
+        // initialize linear system A and target vector y
+        shake256(y, M_ENTRIES_BYTES, tmp, DIGEST_BYTES + SALT_BYTES);
+        build_linear_system(A, y, buf, buf + PK_SEED_BYTES, V);
+
+        // solve linear system Ax = y
+        if (sample_solution(V + PARAM_K * V_BYTES, A, y)) {
+            break;
+        } else {
+            memset(A, 0, sizeof(A));  // reset A for next iteration
+            memset(y, 0, sizeof(y));  // reset y for next iteration
+        }
+    }
+    
+    // compute s from solution x, oil subspace O and vinegar variables V
+    compute_s(sig, V + PARAM_K * V_BYTES, buf + PK_SEED_BYTES, V);
+    // append salt to signature
+    memcpy(sig + SIG_BYTES - SALT_BYTES, tmp + DIGEST_BYTES, SALT_BYTES);
+    // set signature length
+    *siglen = SIG_BYTES;
+
+    // clear sensitive data
+    ctr = 0;
+    memset(buf, 0, sizeof(buf));
+    memset(tmp, 0, sizeof(tmp));
+    memset(V, 0, sizeof(V));
+    memset(A, 0, sizeof(A));
+    memset(y, 0, sizeof(y));
+
+    return MAYO_OK;
+}
+
+int mayo_sign_signature(uint8_t *sig, size_t *siglen,
+                        const uint8_t *m, size_t mlen,
+                        const uint8_t *sk) {
+    uint8_t rnd[R_BYTES];
+#if MAYO_RANDOMIZED_SIGNING
+    // pick randomness for signing
+    if (randombytes(rnd, R_BYTES) != 0) {
+        return MAYO_ERR;  // error in randomness source
+    }
+#else
+    // set randomness for signing to zero
+    memset(rnd, 0, R_BYTES);
+#endif
+    return mayo_sign_signature_internal(sig, siglen, m, mlen, rnd, sk);
+}
+
+int mayo_sign(uint8_t *sm, size_t *smlen, 
+              const uint8_t *m, size_t mlen, 
+              const uint8_t *sk) {
+    size_t siglen = 0;
+    int ret = mayo_sign_signature(sm, &siglen, m, mlen, sk);
+    if (ret != MAYO_OK || siglen != SIG_BYTES) {
+        memset(sm, 0, siglen);
+        *smlen = 0;
+        return ret;
+    }
+    memcpy(sm + SIG_BYTES, m, mlen);
+    *smlen = SIG_BYTES + mlen;
+    return ret;
+}
+
+int mayo_verify(const uint8_t *m, size_t mlen,
+                const uint8_t *sig,
+                const uint8_t *pk) {
+    // contiguous buffer for message digest and salt, or
+    // result vector y of the quadratic map
+    // size is the larger of the two
+#if DIGEST_BYTES + SALT_BYTES > M_ENTRIES_BYTES
+    uint8_t tmp[DIGEST_BYTES + SALT_BYTES];
+#else
+    uint8_t tmp[M_ENTRIES_BYTES];
+#endif
+    uint8_t t[M_ENTRIES_BYTES];  // target vector for verification
+    
+    // compute message digest
+    shake256(tmp, DIGEST_BYTES, m, mlen);
+    // append salt from signature
+    memcpy(tmp + DIGEST_BYTES, sig + SIG_BYTES - SALT_BYTES, SALT_BYTES);
+    // compute target vector t for linear system
+    shake256(t, M_ENTRIES_BYTES, tmp, DIGEST_BYTES + SALT_BYTES);
+
+    // evaluate quadratic map at signature and store result y in tmp
+    quadratic_map(tmp, sig, pk, pk + PK_SEED_BYTES);
+
+    if (memcmp(tmp, t, M_ENTRIES_BYTES) == 0) {
+        return MAYO_OK;  // signature is valid
+    } else {
+        return MAYO_ERR;  // signature is invalid
+    }
+}
+
+int mayo_open(uint8_t *m, size_t *mlen,
+              const uint8_t *sm, size_t smlen,
+              const uint8_t *pk) {
+    if (smlen < SIG_BYTES) {
+        *mlen = 0;
+        return MAYO_ERR;  // signature too short to be valid
+    }
+    int ret = mayo_verify(sm + SIG_BYTES, smlen - SIG_BYTES, sm, pk);
+    if (ret != MAYO_OK) {
+        *mlen = 0;
+        return ret;  // signature verification failed
+    }
+    // signature verification succeeded, copy message to output
+    memcpy(m, sm + SIG_BYTES, smlen - SIG_BYTES);
+    *mlen = smlen - SIG_BYTES;
+    return MAYO_OK;
+}

--- a/crypto_sign/mayo1/m4stack/mayo.h
+++ b/crypto_sign/mayo1/m4stack/mayo.h
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MAYO_H
+#define MAYO_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "config.h"
+#include "params.h"
+
+/**
+ * Status codes
+ */
+#define MAYO_OK 0
+#define MAYO_ERR 1
+
+/**
+ * Mayo keypair generation.
+ *
+ * The implementation corresponds to Mayo.compactKeyGen() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ *
+ * @param[out] pk Mayo public key (allocated array of CPK_BYTES bytes)
+ * @param[out] sk Mayo secret key (allocated array of CSK_BYTES bytes)
+ * @return int status code
+ */
+#define mayo_keypair MAYO_NAMESPACE(keypair)
+int mayo_keypair(uint8_t *pk, uint8_t *sk);
+
+/**
+ * MAYO signature generation.
+ *
+ * The implementation performs Mayo.expandSK() + Mayo.sign() in the Mayo spec.
+ * Keys provided is a compacted secret keys.
+ * The caller is responsible to allocate sufficient memory to hold sm.
+ *
+ * @param[out] sm Signature concatenated with message (allocated array of SIG_BYTES + mlen bytes)
+ * @param[out] smlen Pointer to the length of sm
+ * @param[in] m Message to be signed
+ * @param[in] mlen Message length
+ * @param[in] sk Compacted secret key
+ * @return int status code
+ */
+#define mayo_sign MAYO_NAMESPACE(sign)
+int mayo_sign(uint8_t *sm, size_t *smlen, 
+              const uint8_t *m, size_t mlen, 
+              const uint8_t *sk);
+
+/**
+ * Mayo open signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, the original message is stored in m.
+ * Keys provided is a compact public key.
+ * The caller is responsible to allocate sufficient memory to hold m.
+ *
+ * @param[out] m Message stored if verification succeeds (allocated array of smlen - SIG_BYTES bytes)
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sm Signature concatenated with message
+ * @param[in] smlen Length of sm
+ * @param[in] pk Compacted public key
+ * @return int status code
+ */
+#define mayo_open MAYO_NAMESPACE(open)
+int mayo_open(uint8_t *m, size_t *mlen,
+              const uint8_t *sm, size_t smlen,
+              const uint8_t *pk);
+
+/**
+ * Mayo expand public key.
+ *
+ * The implementation corresponds to Mayo.expandPK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold epk.
+ *
+ * @param[out] epk Expanded public key (allocated array of EPK_BYTES bytes)
+ * @param[in] cpk Compacted public key
+ * @return int return code
+ */
+#define mayo_expand_pk MAYO_NAMESPACE(expand_pk)
+int mayo_expand_pk(uint8_t *epk, const uint8_t *cpk);
+
+/**
+ * Mayo expand secret key.
+ * 
+ * The implementation corresponds to Mayo.expandSK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold expanded_sk.
+ *
+ * @param[out] esk Expanded secret key (allocated array of ESK_BYTES bytes)
+ * @param[in] csk Compacted secret key
+ * @return int return code
+ */
+#define mayo_expand_sk MAYO_NAMESPACE(expand_sk)
+int mayo_expand_sk(uint8_t *esk, const uint8_t *csk);
+
+/**
+ * Mayo verify signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, returns 0, otherwise 1.
+ * Keys provided is a compact public key.
+ *
+ * @param[out] m Message stored if verification succeeds (allocated array of mlen bytes)
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sig Signature
+ * @param[in] pk Compacted public key
+ * @return int 0 if verification succeeded, 1 otherwise.
+ */
+#define mayo_verify MAYO_NAMESPACE(verify)
+int mayo_verify(const uint8_t *m, size_t mlen, 
+                const uint8_t *sig,
+                const uint8_t *pk);
+
+/**
+ * Mayo keypair generation (internal function).
+ *
+ * The implementation performs Mayo.compactKeyGen() in the Mayo spec.
+ * after the sampling of the randomness.
+ * The caller is responsible to allocate sufficient memory to hold pk.
+ * 
+ * @param[out] pk Mayo public key (allocated array of CPK_BYTES bytes)
+ * @param[in] seed_sk Seed for secret key generation (allocated array of SK_SEED_BYTES bytes)
+ * @return int status code
+ */
+#define mayo_keypair_internal MAYO_NAMESPACE(keypair_internal)
+int mayo_keypair_internal(uint8_t *pk, uint8_t *seed_sk);
+
+/**
+ * Mayo signature generation (internal function).
+ *
+ * The implementation performs Mayo.sign() in the Mayo spec.
+ * after the sampling of the randomness rnd (aka R in the spec).
+ * The caller is responsible to allocate sufficient memory to hold sig.
+ * 
+ * @param[out] sig Signature (allocated array of SIG_BYTES bytes)
+ * @param[out] siglen Pointer to the length of sig
+ * @param[in] m Message to be signed
+ * @param[in] mlen Message length
+ * @param[in] rnd Randomness for signing (allocated array of R_BYTES bytes)
+ * @param[in] sk Compacted secret key
+ * @return int status code
+ */
+#define mayo_sign_signature_internal MAYO_NAMESPACE(sign_signature_internal)
+int mayo_sign_signature_internal(uint8_t *sig, size_t *siglen,
+                                 const uint8_t *m, size_t mlen,
+                                 const uint8_t rnd[R_BYTES],
+                                 const uint8_t *sk);
+
+/**
+ * Mayo signature generation.
+ * 
+ * The implementation performs Mayo.sign() in the Mayo spec.
+ * In particular, the randomness for signing is generated and
+ * then passed to the internal signing function mayo_sign_signature_internal.
+ * The caller is responsible to allocate sufficient memory to hold sig.
+ * 
+ * @param[out] sig Signature (allocated array of SIG_BYTES bytes)
+ * @param[out] siglen Pointer to the length of sig
+ * @param[in] m Message to be signed
+ * @param[in] mlen Message length
+ * @param[in] sk Compacted secret key
+ * @return int status code
+ */
+#define mayo_sign_signature MAYO_NAMESPACE(sign_signature)
+int mayo_sign_signature(uint8_t *sig, size_t *siglen,
+                        const uint8_t *m, size_t mlen,
+                        const uint8_t *sk);
+
+#endif  // MAYO_H

--- a/crypto_sign/mayo1/m4stack/mayo.h
+++ b/crypto_sign/mayo1/m4stack/mayo.h
@@ -16,17 +16,65 @@
 #define MAYO_ERR 1
 
 /**
+ * Struct defining MAYO parameters (unused in this implementation)
+ */
+typedef struct {
+    int m;
+    int n;
+    int o;
+    int k;
+    int q;
+    const unsigned char *f_tail;
+    int m_bytes;
+    int O_bytes;
+    int v_bytes;
+    int r_bytes;
+    int R_bytes;
+    int P1_bytes;
+    int P2_bytes;
+    int P3_bytes;
+    int csk_bytes;
+    int cpk_bytes;
+    int sig_bytes;
+    int salt_bytes;
+    int sk_seed_bytes;
+    int digest_bytes;
+    int pk_seed_bytes;
+    int m_vec_limbs;
+    const char *name;
+} mayo_params_t;
+
+/**
+ * Mayo macros and structs to make compatible expand_sk and expand_pk with
+ * https://github.com/PQCMayo/mupq/blob/65bf0719a926720428dd27cf3f863554526cde82/crypto_sign/speed.c
+ */
+#define TO_QWORDS(bytes) (((bytes) + 7) / 8)
+#define P1_LIMBS_MAX (BINOMIAL2(PARAM_N - PARAM_O + 1) * TO_QWORDS(M_ENTRIES_BYTES))
+#define P2_LIMBS_MAX ((PARAM_N - PARAM_O) * PARAM_O * TO_QWORDS(M_ENTRIES_BYTES))
+#define P3_LIMBS_MAX (BINOMIAL2(PARAM_O + 1) * TO_QWORDS(M_ENTRIES_BYTES))
+
+typedef struct sk_t {
+    uint64_t p[P1_LIMBS_MAX + P2_LIMBS_MAX];
+    uint8_t O[PARAM_N * PARAM_O];
+} sk_t;
+
+typedef struct pk_t {
+    uint64_t p[P1_LIMBS_MAX + P2_LIMBS_MAX + P3_LIMBS_MAX];
+} pk_t;
+
+/**
  * Mayo keypair generation.
  *
  * The implementation corresponds to Mayo.compactKeyGen() in the Mayo spec.
  * The caller is responsible to allocate sufficient memory to hold pk and sk.
  *
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[out] pk Mayo public key (allocated array of CPK_BYTES bytes)
  * @param[out] sk Mayo secret key (allocated array of CSK_BYTES bytes)
  * @return int status code
  */
 #define mayo_keypair MAYO_NAMESPACE(keypair)
-int mayo_keypair(uint8_t *pk, uint8_t *sk);
+int mayo_keypair(const mayo_params_t *p, uint8_t *pk, uint8_t *sk);
 
 /**
  * MAYO signature generation.
@@ -35,6 +83,7 @@ int mayo_keypair(uint8_t *pk, uint8_t *sk);
  * Keys provided is a compacted secret keys.
  * The caller is responsible to allocate sufficient memory to hold sm.
  *
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[out] sm Signature concatenated with message (allocated array of SIG_BYTES + mlen bytes)
  * @param[out] smlen Pointer to the length of sm
  * @param[in] m Message to be signed
@@ -43,7 +92,8 @@ int mayo_keypair(uint8_t *pk, uint8_t *sk);
  * @return int status code
  */
 #define mayo_sign MAYO_NAMESPACE(sign)
-int mayo_sign(uint8_t *sm, size_t *smlen, 
+int mayo_sign(const mayo_params_t *p, 
+              uint8_t *sm, size_t *smlen, 
               const uint8_t *m, size_t mlen, 
               const uint8_t *sk);
 
@@ -54,6 +104,7 @@ int mayo_sign(uint8_t *sm, size_t *smlen,
  * Keys provided is a compact public key.
  * The caller is responsible to allocate sufficient memory to hold m.
  *
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[out] m Message stored if verification succeeds (allocated array of smlen - SIG_BYTES bytes)
  * @param[out] mlen Pointer to the length of m
  * @param[in] sm Signature concatenated with message
@@ -62,7 +113,8 @@ int mayo_sign(uint8_t *sm, size_t *smlen,
  * @return int status code
  */
 #define mayo_open MAYO_NAMESPACE(open)
-int mayo_open(uint8_t *m, size_t *mlen,
+int mayo_open(const mayo_params_t *p, 
+              uint8_t *m, size_t *mlen,
               const uint8_t *sm, size_t smlen,
               const uint8_t *pk);
 
@@ -71,26 +123,36 @@ int mayo_open(uint8_t *m, size_t *mlen,
  *
  * The implementation corresponds to Mayo.expandPK() in the Mayo spec.
  * The caller is responsible to allocate sufficient memory to hold epk.
+ * 
+ * In this implementation, the function is a no-op and returns MAYO_OK since
+ * we do not use expanded keys in the signing and verification functions, and
+ * NIST PQC API does not require expand_pk to be implemented.
  *
- * @param[out] epk Expanded public key (allocated array of EPK_BYTES bytes)
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[in] cpk Compacted public key
+ * @param[out] epk Expanded public key
  * @return int return code
  */
 #define mayo_expand_pk MAYO_NAMESPACE(expand_pk)
-int mayo_expand_pk(uint8_t *epk, const uint8_t *cpk);
+int mayo_expand_pk(const mayo_params_t *p, const uint8_t *cpk, uint64_t *epk);
 
 /**
  * Mayo expand secret key.
  * 
  * The implementation corresponds to Mayo.expandSK() in the Mayo spec.
  * The caller is responsible to allocate sufficient memory to hold expanded_sk.
+ * 
+ * In this implementation, the function is a no-op and returns MAYO_OK since
+ * we do not use expanded keys in the signing and verification functions, and
+ * NIST PQC API does not require expand_sk to be implemented.
  *
- * @param[out] esk Expanded secret key (allocated array of ESK_BYTES bytes)
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
+ * @param[out] esk Expanded secret key
  * @param[in] csk Compacted secret key
  * @return int return code
  */
 #define mayo_expand_sk MAYO_NAMESPACE(expand_sk)
-int mayo_expand_sk(uint8_t *esk, const uint8_t *csk);
+int mayo_expand_sk(const mayo_params_t *p, const uint8_t *csk, sk_t *esk);
 
 /**
  * Mayo verify signature.
@@ -98,6 +160,7 @@ int mayo_expand_sk(uint8_t *esk, const uint8_t *csk);
  * The implementation performs Mayo.verify(). If the signature verification succeeded, returns 0, otherwise 1.
  * Keys provided is a compact public key.
  *
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[out] m Message stored if verification succeeds (allocated array of mlen bytes)
  * @param[out] mlen Pointer to the length of m
  * @param[in] sig Signature
@@ -105,7 +168,8 @@ int mayo_expand_sk(uint8_t *esk, const uint8_t *csk);
  * @return int 0 if verification succeeded, 1 otherwise.
  */
 #define mayo_verify MAYO_NAMESPACE(verify)
-int mayo_verify(const uint8_t *m, size_t mlen, 
+int mayo_verify(const mayo_params_t *p, 
+                const uint8_t *m, size_t mlen, 
                 const uint8_t *sig,
                 const uint8_t *pk);
 
@@ -116,12 +180,13 @@ int mayo_verify(const uint8_t *m, size_t mlen,
  * after the sampling of the randomness.
  * The caller is responsible to allocate sufficient memory to hold pk.
  * 
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[out] pk Mayo public key (allocated array of CPK_BYTES bytes)
  * @param[in] seed_sk Seed for secret key generation (allocated array of SK_SEED_BYTES bytes)
  * @return int status code
  */
 #define mayo_keypair_internal MAYO_NAMESPACE(keypair_internal)
-int mayo_keypair_internal(uint8_t *pk, uint8_t *seed_sk);
+int mayo_keypair_internal(const mayo_params_t *p, uint8_t *pk, uint8_t *seed_sk);
 
 /**
  * Mayo signature generation (internal function).
@@ -130,6 +195,7 @@ int mayo_keypair_internal(uint8_t *pk, uint8_t *seed_sk);
  * after the sampling of the randomness rnd (aka R in the spec).
  * The caller is responsible to allocate sufficient memory to hold sig.
  * 
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[out] sig Signature (allocated array of SIG_BYTES bytes)
  * @param[out] siglen Pointer to the length of sig
  * @param[in] m Message to be signed
@@ -139,7 +205,8 @@ int mayo_keypair_internal(uint8_t *pk, uint8_t *seed_sk);
  * @return int status code
  */
 #define mayo_sign_signature_internal MAYO_NAMESPACE(sign_signature_internal)
-int mayo_sign_signature_internal(uint8_t *sig, size_t *siglen,
+int mayo_sign_signature_internal(const mayo_params_t *p,
+                                 uint8_t *sig, size_t *siglen,
                                  const uint8_t *m, size_t mlen,
                                  const uint8_t rnd[R_BYTES],
                                  const uint8_t *sk);
@@ -152,6 +219,7 @@ int mayo_sign_signature_internal(uint8_t *sig, size_t *siglen,
  * then passed to the internal signing function mayo_sign_signature_internal.
  * The caller is responsible to allocate sufficient memory to hold sig.
  * 
+ * @param[in] p Mayo parameter set (ignored in this implementation, can be set to NULL)
  * @param[out] sig Signature (allocated array of SIG_BYTES bytes)
  * @param[out] siglen Pointer to the length of sig
  * @param[in] m Message to be signed
@@ -160,7 +228,8 @@ int mayo_sign_signature_internal(uint8_t *sig, size_t *siglen,
  * @return int status code
  */
 #define mayo_sign_signature MAYO_NAMESPACE(sign_signature)
-int mayo_sign_signature(uint8_t *sig, size_t *siglen,
+int mayo_sign_signature(const mayo_params_t *p,
+                        uint8_t *sig, size_t *siglen,
                         const uint8_t *m, size_t mlen,
                         const uint8_t *sk);
 

--- a/crypto_sign/mayo1/m4stack/params.h
+++ b/crypto_sign/mayo1/m4stack/params.h
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+The structure of this file is inspired by https://github.com/pq-crystals/dilithium.git
+*/
+
+#ifndef PARAMS_H
+#define PARAMS_H
+
+#include "config.h"
+
+#define PARAM_Q 16  // cardinality of the field
+#define PK_SEED_BYTES 16  // number of bytes in the seed used to generate P1 and P2
+
+#if MAYO_MODE == 1
+#define PARAM_N 86
+#define PARAM_M 78
+#define PARAM_O 8
+#define PARAM_K 10
+#define SALT_BYTES 24  // number of bytes in the salt used for signing
+#define DIGEST_BYTES 32  // number of bytes in the digest of the message to be signed
+#define F_TAIL0 8  // constant coefficient in f(z) = z^78 + z^2 + z + x^3
+#define F_TAIL1 1  // coefficient of z in f(z) = z^78 + z^2 + z + x^3
+#define F_TAIL2 1  // coefficient of z^2 in f(z) = z^78 + z^2 + z + x^3
+#define F_TAIL3 0  // coefficient of z^3 in f(z) = z^78 + z^2 + z + x^3
+
+#elif MAYO_MODE == 2
+#define PARAM_N 81
+#define PARAM_M 64
+#define PARAM_O 17
+#define PARAM_K 4
+#define SALT_BYTES 24  // number of bytes in the salt used for signing
+#define DIGEST_BYTES 32  // number of bytes in the digest of the message to be signed
+#define F_TAIL0 8  // constant coefficient in f(z) = z^64 + x^3*z^3 + x*z^2 + x^3
+#define F_TAIL1 0  // coefficient of z in f(z) = z^64 + x^3*z^3 + x*z^2 + x^3
+#define F_TAIL2 2  // coefficient of z^2 in f(z) = z^64 + x^3*z^3 + x*z^2 + x^3
+#define F_TAIL3 8  // coefficient of z^3 in f(z) = z^64 + x^3*z^3 + x*z^2 + x^3
+
+#elif MAYO_MODE == 3
+#define PARAM_N 118
+#define PARAM_M 108
+#define PARAM_O 10
+#define PARAM_K 11
+#define SALT_BYTES 32  // number of bytes in the salt used for signing
+#define DIGEST_BYTES 48  // number of bytes in the digest of the message to be signed
+#define F_TAIL0 8  // constant coefficient in f(z) = z^108 + (x^2 + x + 1)*z^3 + z^2 + x^3
+#define F_TAIL1 0  // coefficient of z in f(z) = z^108 + (x^2 + x + 1)*z^3 + z^2 + x^3
+#define F_TAIL2 1  // coefficient of z^2 in f(z) = z^108 + (x^2 + x + 1)*z^3 + z^2 + x^3
+#define F_TAIL3 7  // coefficient of z^3 in f(z) = z^108 + (x^2 + x + 1)*z^3 + z^2 + x^3
+
+#elif MAYO_MODE == 5
+#define PARAM_N 154
+#define PARAM_M 142
+#define PARAM_O 12
+#define PARAM_K 12
+#define SALT_BYTES 40  // number of bytes in the salt used for signing
+#define DIGEST_BYTES 64  // number of bytes in the digest of the message to be signed
+#define F_TAIL0 4  // constant coefficient in f(z) = z^142 + z^3 + x^3*z^2 + x^2
+#define F_TAIL1 0  // coefficient of z in f(z) = z^142 + z^3 + x^3*z^2 + x^2
+#define F_TAIL2 8  // coefficient of z^2 in f(z) = z^142 + z^3 + x^3*z^2 + x^2
+#define F_TAIL3 1  // coefficient of z^3 in f(z) = z^142 + z^3 + x^3*z^2 + x^2
+
+#else
+#error "Unsupported MAYO_MODE"
+
+#endif
+
+#if PARAM_N != PARAM_M + PARAM_O
+// sanity check since the implementation assumes N = M + O
+#error "PARAM_N must be equal to PARAM_M + PARAM_O"
+#endif
+
+#if PARAM_M % 2 != 0
+// sanity check since the implementation assumes PARAM_M is even
+#error "PARAM_M must be even"
+#endif
+
+#if PARAM_O % 2 != 0 && PARAM_K % 2 != 0
+// sanity check since the implementation assumes at least one of PARAM_O or PARAM_K is even
+#error "PARAM_O and PARAM_K cannot both be odd"
+#endif
+
+#define BINOMIAL2(n) (((n) * ((n) - 1)) / 2)
+
+#define SK_SEED_BYTES SALT_BYTES  // number of bytes in the seed used to generate the secret key
+#define R_BYTES SALT_BYTES  // number of bytes in the random coins used for signing
+#define O_BYTES (((PARAM_N - PARAM_O)*PARAM_O + 1)/2)  // number of bytes to represent the O matrix
+#define V_BYTES ((PARAM_N - PARAM_O + 1)/2)  // number of bytes to store the vinegar variables
+#define P1_BYTES (PARAM_M * BINOMIAL2(PARAM_N - PARAM_O + 1) / 2)  // number of bytes to represent the P1 matrices
+#define P2_BYTES (PARAM_M * ((PARAM_N - PARAM_O)*PARAM_O) / 2)  // number of bytes to represent the P2 matrices
+#define P3_BYTES (PARAM_M * BINOMIAL2(PARAM_O + 1) / 2)  // number of bytes to represent the P3 matrices
+#define L_BYTES (PARAM_M * (PARAM_N - PARAM_O)*PARAM_O / 2)  // number of bytes to represent the L matrices
+
+#define CSK_BYTES SK_SEED_BYTES  // number of bytes in the compact representation of a secret key
+#define ESK_BYTES (SK_SEED_BYTES + O_BYTES + P1_BYTES + L_BYTES)  // number of bytes in the expanded representation of a secret key
+#define CPK_BYTES (PK_SEED_BYTES + P3_BYTES)  // number of bytes in the compact representation of a public key
+#define EPK_BYTES (P1_BYTES + P2_BYTES + P3_BYTES)  // number of bytes in the expanded representation of a public key
+#define SIG_BYTES ((PARAM_N * PARAM_K + 1)/2 + SALT_BYTES)  // number of bytes in a signature
+
+#define M_ENTRIES_BYTES (PARAM_M / 2)  // number of bytes to store M GF(16) elements
+#define KO_ENTRIES_BYTES ((PARAM_K * PARAM_O) / 2)  // number of bytes to store k*o GF(16) elements
+
+#endif  // PARAMS_H

--- a/crypto_sign/mayo1/m4stack/params.h
+++ b/crypto_sign/mayo1/m4stack/params.h
@@ -100,4 +100,7 @@ The structure of this file is inspired by https://github.com/pq-crystals/dilithi
 #define M_ENTRIES_BYTES (PARAM_M / 2)  // number of bytes to store M GF(16) elements
 #define KO_ENTRIES_BYTES ((PARAM_K * PARAM_O) / 2)  // number of bytes to store k*o GF(16) elements
 
+#define TO_BYTES(len) (((len) + 1) / 2)
+#define TO_QWORDS(bytes) (((bytes) + 7) / 8)
+
 #endif  // PARAMS_H

--- a/crypto_sign/mayo1/m4stack/randombytes.h
+++ b/crypto_sign/mayo1/m4stack/randombytes.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RANDOMBYTES_H
+#define RANDOMBYTES_H
+
+#include <stdlib.h>
+
+/**
+ * Randombytes initialization.
+ * Initialization may be needed for some random number generators (e.g. CTR-DRBG).
+ *
+ * @param[in] entropy_input 48 bytes entropy input
+ * @param[in] personalization_string Personalization string
+ * @param[in] security_strength Security string
+ */
+void randombytes_init(unsigned char *entropy_input,
+                      unsigned char *personalization_string,
+                      int security_strength);
+
+/**
+ * Random byte generation.
+ * The caller is responsible to allocate sufficient memory to hold x.
+ *
+ * @param[out] x Memory to hold the random bytes.
+ * @param[in] xlen Number of random bytes to be generated
+ * @return int 0 on success, -1 otherwise
+ */
+int randombytes(unsigned char *x, size_t xlen);
+
+#endif  // RANDOMBYTES_H
+

--- a/crypto_sign/mayo2/m4stack/aes_ctr.c
+++ b/crypto_sign/mayo2/m4stack/aes_ctr.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/aes_ctr.c

--- a/crypto_sign/mayo2/m4stack/aes_ctr.h
+++ b/crypto_sign/mayo2/m4stack/aes_ctr.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/aes_ctr.h

--- a/crypto_sign/mayo2/m4stack/api.c
+++ b/crypto_sign/mayo2/m4stack/api.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/api.c

--- a/crypto_sign/mayo2/m4stack/api.h
+++ b/crypto_sign/mayo2/m4stack/api.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/api.h

--- a/crypto_sign/mayo2/m4stack/arithmetic.c
+++ b/crypto_sign/mayo2/m4stack/arithmetic.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/arithmetic.c

--- a/crypto_sign/mayo2/m4stack/arithmetic.h
+++ b/crypto_sign/mayo2/m4stack/arithmetic.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/arithmetic.h

--- a/crypto_sign/mayo2/m4stack/blocker.c
+++ b/crypto_sign/mayo2/m4stack/blocker.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/blocker.c

--- a/crypto_sign/mayo2/m4stack/blocker.h
+++ b/crypto_sign/mayo2/m4stack/blocker.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/blocker.h

--- a/crypto_sign/mayo2/m4stack/comparison.h
+++ b/crypto_sign/mayo2/m4stack/comparison.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/comparison.h

--- a/crypto_sign/mayo2/m4stack/config.h
+++ b/crypto_sign/mayo2/m4stack/config.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+The structure of this file is inspired by https://github.com/pq-crystals/dilithium.git
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#ifndef MAYO_RANDOMIZED_SIGNING
+#define MAYO_RANDOMIZED_SIGNING 1
+#endif
+
+#if MAYO_RANDOMIZED_SIGNING != 0 && MAYO_RANDOMIZED_SIGNING != 1
+#error "MAYO_RANDOMIZED_SIGNING must be either 0 or 1"
+#endif
+
+#ifndef MAYO_MODE
+#define MAYO_MODE 2
+#endif
+
+#if MAYO_MODE == 1
+#define CRYPTO_ALGNAME "MAYO_1"
+#define MAYO_NAMESPACETOP mayo1
+#define MAYO_NAMESPACE(s) mayo1_##s
+#elif MAYO_MODE == 2
+#define CRYPTO_ALGNAME "MAYO_2"
+#define MAYO_NAMESPACETOP mayo2
+#define MAYO_NAMESPACE(s) mayo2_##s
+#elif MAYO_MODE == 3
+#define CRYPTO_ALGNAME "MAYO_3"
+#define MAYO_NAMESPACETOP mayo3
+#define MAYO_NAMESPACE(s) mayo3_##s
+#elif MAYO_MODE == 5
+#define CRYPTO_ALGNAME "MAYO_5"
+#define MAYO_NAMESPACETOP mayo5
+#define MAYO_NAMESPACE(s) mayo5_##s
+#else
+#error "Unsupported MAYO_MODE"
+#endif // MAYO_MODE
+
+#ifndef USE_BLOCKERS
+#define USE_BLOCKERS 1
+#endif
+
+#if USE_BLOCKERS != 0 && USE_BLOCKERS != 1
+#error "USE_BLOCKERS must be either 0 or 1"
+#endif
+
+#endif  // CONFIG_H

--- a/crypto_sign/mayo2/m4stack/mayo.c
+++ b/crypto_sign/mayo2/m4stack/mayo.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/mayo.c

--- a/crypto_sign/mayo2/m4stack/mayo.h
+++ b/crypto_sign/mayo2/m4stack/mayo.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/mayo.h

--- a/crypto_sign/mayo2/m4stack/params.h
+++ b/crypto_sign/mayo2/m4stack/params.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/params.h

--- a/crypto_sign/mayo2/m4stack/randombytes.h
+++ b/crypto_sign/mayo2/m4stack/randombytes.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/randombytes.h

--- a/crypto_sign/mayo3/m4stack/aes_ctr.c
+++ b/crypto_sign/mayo3/m4stack/aes_ctr.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/aes_ctr.c

--- a/crypto_sign/mayo3/m4stack/aes_ctr.h
+++ b/crypto_sign/mayo3/m4stack/aes_ctr.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/aes_ctr.h

--- a/crypto_sign/mayo3/m4stack/api.c
+++ b/crypto_sign/mayo3/m4stack/api.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/api.c

--- a/crypto_sign/mayo3/m4stack/api.h
+++ b/crypto_sign/mayo3/m4stack/api.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/api.h

--- a/crypto_sign/mayo3/m4stack/arithmetic.c
+++ b/crypto_sign/mayo3/m4stack/arithmetic.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/arithmetic.c

--- a/crypto_sign/mayo3/m4stack/arithmetic.h
+++ b/crypto_sign/mayo3/m4stack/arithmetic.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/arithmetic.h

--- a/crypto_sign/mayo3/m4stack/blocker.c
+++ b/crypto_sign/mayo3/m4stack/blocker.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/blocker.c

--- a/crypto_sign/mayo3/m4stack/blocker.h
+++ b/crypto_sign/mayo3/m4stack/blocker.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/blocker.h

--- a/crypto_sign/mayo3/m4stack/comparison.h
+++ b/crypto_sign/mayo3/m4stack/comparison.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/comparison.h

--- a/crypto_sign/mayo3/m4stack/config.h
+++ b/crypto_sign/mayo3/m4stack/config.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+The structure of this file is inspired by https://github.com/pq-crystals/dilithium.git
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#ifndef MAYO_RANDOMIZED_SIGNING
+#define MAYO_RANDOMIZED_SIGNING 1
+#endif
+
+#if MAYO_RANDOMIZED_SIGNING != 0 && MAYO_RANDOMIZED_SIGNING != 1
+#error "MAYO_RANDOMIZED_SIGNING must be either 0 or 1"
+#endif
+
+#ifndef MAYO_MODE
+#define MAYO_MODE 3
+#endif
+
+#if MAYO_MODE == 1
+#define CRYPTO_ALGNAME "MAYO_1"
+#define MAYO_NAMESPACETOP mayo1
+#define MAYO_NAMESPACE(s) mayo1_##s
+#elif MAYO_MODE == 2
+#define CRYPTO_ALGNAME "MAYO_2"
+#define MAYO_NAMESPACETOP mayo2
+#define MAYO_NAMESPACE(s) mayo2_##s
+#elif MAYO_MODE == 3
+#define CRYPTO_ALGNAME "MAYO_3"
+#define MAYO_NAMESPACETOP mayo3
+#define MAYO_NAMESPACE(s) mayo3_##s
+#elif MAYO_MODE == 5
+#define CRYPTO_ALGNAME "MAYO_5"
+#define MAYO_NAMESPACETOP mayo5
+#define MAYO_NAMESPACE(s) mayo5_##s
+#else
+#error "Unsupported MAYO_MODE"
+#endif // MAYO_MODE
+
+#ifndef USE_BLOCKERS
+#define USE_BLOCKERS 1
+#endif
+
+#if USE_BLOCKERS != 0 && USE_BLOCKERS != 1
+#error "USE_BLOCKERS must be either 0 or 1"
+#endif
+
+#endif  // CONFIG_H

--- a/crypto_sign/mayo3/m4stack/mayo.c
+++ b/crypto_sign/mayo3/m4stack/mayo.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/mayo.c

--- a/crypto_sign/mayo3/m4stack/mayo.h
+++ b/crypto_sign/mayo3/m4stack/mayo.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/mayo.h

--- a/crypto_sign/mayo3/m4stack/params.h
+++ b/crypto_sign/mayo3/m4stack/params.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/params.h

--- a/crypto_sign/mayo3/m4stack/randombytes.h
+++ b/crypto_sign/mayo3/m4stack/randombytes.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/randombytes.h

--- a/crypto_sign/mayo5/m4stack/aes_ctr.c
+++ b/crypto_sign/mayo5/m4stack/aes_ctr.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/aes_ctr.c

--- a/crypto_sign/mayo5/m4stack/aes_ctr.h
+++ b/crypto_sign/mayo5/m4stack/aes_ctr.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/aes_ctr.h

--- a/crypto_sign/mayo5/m4stack/api.c
+++ b/crypto_sign/mayo5/m4stack/api.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/api.c

--- a/crypto_sign/mayo5/m4stack/api.h
+++ b/crypto_sign/mayo5/m4stack/api.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/api.h

--- a/crypto_sign/mayo5/m4stack/arithmetic.c
+++ b/crypto_sign/mayo5/m4stack/arithmetic.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/arithmetic.c

--- a/crypto_sign/mayo5/m4stack/arithmetic.h
+++ b/crypto_sign/mayo5/m4stack/arithmetic.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/arithmetic.h

--- a/crypto_sign/mayo5/m4stack/blocker.c
+++ b/crypto_sign/mayo5/m4stack/blocker.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/blocker.c

--- a/crypto_sign/mayo5/m4stack/blocker.h
+++ b/crypto_sign/mayo5/m4stack/blocker.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/blocker.h

--- a/crypto_sign/mayo5/m4stack/comparison.h
+++ b/crypto_sign/mayo5/m4stack/comparison.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/comparison.h

--- a/crypto_sign/mayo5/m4stack/config.h
+++ b/crypto_sign/mayo5/m4stack/config.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+The structure of this file is inspired by https://github.com/pq-crystals/dilithium.git
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#ifndef MAYO_RANDOMIZED_SIGNING
+#define MAYO_RANDOMIZED_SIGNING 1
+#endif
+
+#if MAYO_RANDOMIZED_SIGNING != 0 && MAYO_RANDOMIZED_SIGNING != 1
+#error "MAYO_RANDOMIZED_SIGNING must be either 0 or 1"
+#endif
+
+#ifndef MAYO_MODE
+#define MAYO_MODE 5
+#endif
+
+#if MAYO_MODE == 1
+#define CRYPTO_ALGNAME "MAYO_1"
+#define MAYO_NAMESPACETOP mayo1
+#define MAYO_NAMESPACE(s) mayo1_##s
+#elif MAYO_MODE == 2
+#define CRYPTO_ALGNAME "MAYO_2"
+#define MAYO_NAMESPACETOP mayo2
+#define MAYO_NAMESPACE(s) mayo2_##s
+#elif MAYO_MODE == 3
+#define CRYPTO_ALGNAME "MAYO_3"
+#define MAYO_NAMESPACETOP mayo3
+#define MAYO_NAMESPACE(s) mayo3_##s
+#elif MAYO_MODE == 5
+#define CRYPTO_ALGNAME "MAYO_5"
+#define MAYO_NAMESPACETOP mayo5
+#define MAYO_NAMESPACE(s) mayo5_##s
+#else
+#error "Unsupported MAYO_MODE"
+#endif // MAYO_MODE
+
+#ifndef USE_BLOCKERS
+#define USE_BLOCKERS 1
+#endif
+
+#if USE_BLOCKERS != 0 && USE_BLOCKERS != 1
+#error "USE_BLOCKERS must be either 0 or 1"
+#endif
+
+#endif  // CONFIG_H

--- a/crypto_sign/mayo5/m4stack/mayo.c
+++ b/crypto_sign/mayo5/m4stack/mayo.c
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/mayo.c

--- a/crypto_sign/mayo5/m4stack/mayo.h
+++ b/crypto_sign/mayo5/m4stack/mayo.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/mayo.h

--- a/crypto_sign/mayo5/m4stack/params.h
+++ b/crypto_sign/mayo5/m4stack/params.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/params.h

--- a/crypto_sign/mayo5/m4stack/randombytes.h
+++ b/crypto_sign/mayo5/m4stack/randombytes.h
@@ -1,0 +1,1 @@
+../../mayo1/m4stack/randombytes.h


### PR DESCRIPTION
Adds a stack-efficient implementation of MAYO-1; other parameters can be chosen by modifying the `MAYO_MODE` macro in  `config.h`. The implementation is written in C without native functions for Cortex-M4.

The main idea was to expand the pk, `m` entries at a time, perform the operations that require those entries, discard them, repeat. Also, all operations are done without unpacking the nibbles, which further halves the stack requirement.

- [ ] AES-128-CTR stream native
- [ ] EF native
- [ ] Arithmetic functions native
- [x] Tests pass in qemu
- [x] Testvectors pass in qemu
- [ ] Tests pass on a board
- [ ] Testvectors pass on a board
- [ ] Run benchmarks on a board